### PR TITLE
Added LGCM to taxons. 

### DIFF
--- a/src/Taxonomy.jl
+++ b/src/Taxonomy.jl
@@ -27,6 +27,8 @@ module Taxonomy
     include("taxons/taxon.jl")
     export GFactor
     include("taxons/cfa.jl")
+    export LGCM
+    include("taxons/lgcm.jl")
 
     import UUIDs
     export generate_id

--- a/src/taxons/lgcm.jl
+++ b/src/taxons/lgcm.jl
@@ -1,0 +1,17 @@
+struct LGCM <: Taxon
+    timecoding::Judgement 
+    ntimepoints::Judgement
+    npredictors::Judgement
+    nonlinearfunction::Judgement
+end
+
+function LGCM(; timecoding, 
+    ntimepoints = length(timecoding),
+    npredictors = 0,
+    nonlinearfunction = 0)
+    LGCM(timecoding, 
+        ntimepoints, 
+        npredictors, 
+        nonlinearfunction
+        )
+end

--- a/test/taxons.jl
+++ b/test/taxons.jl
@@ -1,0 +1,9 @@
+using Taxonomy
+using Test
+
+mylgcm_sparse = LGCM(timecoding = [0,1,2,3,4])
+mylgcm = LGCM(timecoding = [0,1,2,3,4], ntimepoints = 5, npredictors = 0, nonlinearfunction = 0)
+
+@testset "LGCM" begin
+    @test mylgcm.ntimepoints.rating == mylgcm_sparse.ntimepoints.rating == 5
+end


### PR DESCRIPTION
Added first LGCM draft to taxons.
LGCM(timecoding = []) takes a vector of the (most times ) fixed paths for modelling the time intervals. From this, by default LGCM(ntimepoints = length(timecoding)) is set, so in many cases only ntimepoints needs to be specified in the taxonomy. But maybe this is too error prone? Are there scenarios, where ntimepoints != length(timecoding)?