### PR TITLE
treat lgcm types more lax

### DIFF
--- a/src/judgement.jl
+++ b/src/judgement.jl
@@ -16,7 +16,9 @@ struct Judgement{T}
     certainty::Float64
     location::Union{String, Missing}
     function Judgement{T}(r, c, l) where T
-        if ((c < 0.0) || (c > 1.0))
+        if isa(r, Judgement)
+            throw(ArgumentError("A Judgement of a Judgment is too meta for my taste."))
+        elseif ((c < 0.0) || (c > 1.0))
             throw(ArgumentError("Certainty must be between 0 and 1."))
         else
             new{T}(r, c, l)
@@ -26,8 +28,8 @@ end
 Judgement(r::T, c = 1.0, l = missing) where T = Judgement{T}(r, c, l)
 Judgement{T}(r::T) where T = Judgement{T}(r, 1.0, missing)
 Judgement{T}(r::T, c) where T = Judgement{T}(r, c, missing)
-
 Judgement(;rating, certainty = 1.0, location = missing) = Judgement(rating, certainty, location)
+Judgement(x::Judgement) = x
 
 """
 Extract rating from Judgement.

--- a/src/taxons/cfa.jl
+++ b/src/taxons/cfa.jl
@@ -1,8 +1,10 @@
 struct GFactor <: AbstractCFA
-    nobserved::Judgement{Int}
-    nerror_covariances::Judgement{Int}
-    crossloading_incoming::Judgement{Int}
-    crossloading_outgoing::Judgement{Int}
+    nobserved::Judgement{ <: Int}
+    nerror_covariances::Judgement{ <: Int}
+    crossloading_incoming::Judgement{ <: Int}
+    crossloading_outgoing::Judgement{ <: Int}
+    GFactor(nobserved, nerror_covariances, crossloading_incoming, crossloading_outgoing) =
+        new(J(nobserved), J(nerror_covariances), J(crossloading_incoming), J(crossloading_outgoing))
 end
 
 function GFactor(;nobserved,

--- a/src/taxons/lgcm.jl
+++ b/src/taxons/lgcm.jl
@@ -6,17 +6,18 @@ struct LGCM <: Taxon
 end
 
 function LGCM(; 
-    timecoding, 
-    ntimepoints =  
-    if isa(timecoding, Vector{<:Number})
-        length(timecoding)
-    elseif ismissing(timecoding)
-        missing
-    else
-        throw(DomainError(timecoding, "please provide a numeric vector or missing for timecoding argument"))
-    end,
+    timecoding = NoJudgement(), 
+    ntimepoints = NoJudgement(),
     npredictors = 0,
     nonlinearfunction = 0)
+
+    implied_ntimepoints = length(rating(timecoding))
+    if ismissing(rating(ntimepoints))
+        ntimepoints = implied_ntimepoints
+    end
+    if !ismissing(rating(timecoding)) && ntimepoints != implied_ntimepoints
+        throw(DomainError("ntimepoints does not aggree with ntimepoints"))
+    end
     LGCM(timecoding, 
         ntimepoints, 
         npredictors, 

--- a/src/taxons/lgcm.jl
+++ b/src/taxons/lgcm.jl
@@ -1,8 +1,10 @@
 struct LGCM <: Taxon
-    timecoding::Judgement{Union{AbstractArray{Number}, Missing}}
-    ntimepoints::Judgement{Union{Int, Missing}}
-    npredictors::Judgement{Union{Int, Missing}}
-    nonlinearfunction::Judgement{Union{Int, Missing}}
+    timecoding::Judgement{ <: Union{ <: AbstractArray{ <: Number}, Missing}}
+    ntimepoints::Judgement{ <: Union{ <: Int, Missing}}
+    npredictors::Judgement{ <: Union{ <: Int, Missing}}
+    nonlinearfunction::Judgement{ <: Union{ <: Int, Missing}}
+    LGCM(timecoding, ntimepoints, npredictors, nonlinearfunction) =
+        new(J(timecoding), J(ntimepoints), J(npredictors), J(nonlinearfunction))
 end
 
 function LGCM(; 

--- a/src/taxons/lgcm.jl
+++ b/src/taxons/lgcm.jl
@@ -10,14 +10,16 @@ function LGCM(;
     ntimepoints = NoJudgement(),
     npredictors = 0,
     nonlinearfunction = 0)
-
-    implied_ntimepoints = length(rating(timecoding))
-    if ismissing(rating(ntimepoints))
-        ntimepoints = implied_ntimepoints
+    if !ismissing(rating(timecoding))
+        implied_ntimepoints = length(rating(timecoding))
+        if ismissing(rating(ntimepoints))
+            ntimepoints = implied_ntimepoints
+        end
+        if ntimepoints != implied_ntimepoints
+            throw(ArgumentError("ntimepoints does not aggree with ntimepoints"))
+        end
     end
-    if !ismissing(rating(timecoding)) && ntimepoints != implied_ntimepoints
-        throw(ArgumentError("ntimepoints does not aggree with ntimepoints"))
-    end
+    
     LGCM(timecoding, 
         ntimepoints, 
         npredictors, 

--- a/src/taxons/lgcm.jl
+++ b/src/taxons/lgcm.jl
@@ -16,7 +16,7 @@ function LGCM(;
         ntimepoints = implied_ntimepoints
     end
     if !ismissing(rating(timecoding)) && ntimepoints != implied_ntimepoints
-        throw(DomainError("ntimepoints does not aggree with ntimepoints"))
+        throw(ArgumentError("ntimepoints does not aggree with ntimepoints"))
     end
     LGCM(timecoding, 
         ntimepoints, 

--- a/test/judgement.jl
+++ b/test/judgement.jl
@@ -3,6 +3,7 @@
     @test J(missing) == Judgement(missing, 1.0)
     @test convert(Judgement, 2.0) == Judgement(2.0, 1.0)
     @test_throws ArgumentError Judgement(2.0, 2.0)
+    @test_throws ArgumentError Judgement(J("hi"), 2.0)
     @test isequal(rating(J(1.3)), 1.3)
     @test isequal(certainty(J(1.3)), 1.0)
     @test isequal(location(J(1.3)), missing)

--- a/test/judgement.jl
+++ b/test/judgement.jl
@@ -1,9 +1,16 @@
-@testset "Judgment" begin
+@testset "Judgment standard values" begin
     @test J(1.3) == Judgement(1.3, 1.0)
     @test J(missing) == Judgement(missing, 1.0)
+    @test J{Int}(1, .5) == Judgement(1, .5, missing)
+end
+
+@testset "Judgment" begin
     @test convert(Judgement, 2.0) == Judgement(2.0, 1.0)
     @test_throws ArgumentError Judgement(2.0, 2.0)
     @test_throws ArgumentError Judgement(J("hi"), 2.0)
+end
+
+@testset "Judgment Getter" begin
     @test isequal(rating(J(1.3)), 1.3)
     @test isequal(certainty(J(1.3)), 1.0)
     @test isequal(location(J(1.3)), missing)

--- a/test/taxons/cfa.jl
+++ b/test/taxons/cfa.jl
@@ -1,3 +1,4 @@
 @testset "CFA" begin
     @test GFactor(10, 0, 0, 0) == GFactor(nobserved = J(10), nerror_covariances = J(0))
+    @test_throws MethodError GFactor(nobserved = "hi", nerror_covariances = 0)
 end

--- a/test/taxons/lgcm.jl
+++ b/test/taxons/lgcm.jl
@@ -1,11 +1,11 @@
 mylgcm_sparse = LGCM(timecoding = [0,1,2,3,4])
 mylgcm = LGCM(timecoding = [0,1,2,3,4], ntimepoints = 5, npredictors = 0, nonlinearfunction = 0)
-mylgcm_missing = LGCM(timecoding = missing)
+mylgcm_missing = LGCM(timecoding = J(missing))
 
 
 @testset "LGCM" begin
     @test mylgcm.ntimepoints.rating == mylgcm_sparse.ntimepoints.rating == 5
-    @test_throws DomainError LGCM(timecoding = "test")
-    @test_throws DomainError LGCM(timecoding = 1)
-    @test mylgcm_missing.ntimepoints == J(missing, 1.0, missing)
+    @test_throws MethodError LGCM(timecoding = "test")
+    @test_throws MethodError LGCM(timecoding = 1)
+    @test mylgcm_missing.ntimepoints == J(missing, 0.0, missing)
 end

--- a/test/taxons/lgcm.jl
+++ b/test/taxons/lgcm.jl
@@ -8,4 +8,5 @@ mylgcm_missing = LGCM(timecoding = J(missing))
     @test_throws MethodError LGCM(timecoding = "test")
     @test_throws MethodError LGCM(timecoding = 1)
     @test mylgcm_missing.ntimepoints == J(missing, 0.0, missing)
+    @test_throws ArgumentError LGCM(timecoding = 1:4, ntimepoints = 3)
 end


### PR DESCRIPTION
The logic for type checking and for setting standard values was entangled. Now, no type checking is done while setting standard values. Instead, it is more duck-typing, e.g., #14 gets closed without being a special case as in #15. However, #16 reintroduces more stringent type checking.
It also checks that ntimepoints and timecoding agree.