### PR TITLE
Filter for RecordDataBase

### DIFF
--- a/src/Taxonomy.jl
+++ b/src/Taxonomy.jl
@@ -64,7 +64,7 @@ module Taxonomy
     export Model
     include("model.jl")
 
-    export factor_variance, structural_model, doi
+    export factor_variance, structural_model, doi, measurement_model
     include("extractors.jl")
 
     include("filter.jl")

--- a/src/Taxonomy.jl
+++ b/src/Taxonomy.jl
@@ -30,6 +30,7 @@ module Taxonomy
     
     import Base.convert, Base.==
     export Judgements, J, Judgement, NoJudgement, convert, rating, comment, certainty
+    export Empirical, Lang, N, Standardized, Quest
     export JudgementNumber, JudgementBool, JudgementInt, JudgementString
     export JudgementVecNumber, JudgementVecBool, JudgementVecInt, JudgementVecString
     include("judgements/Judgements.jl")

--- a/src/Taxonomy.jl
+++ b/src/Taxonomy.jl
@@ -17,6 +17,16 @@ module Taxonomy
 
     export DOI, UsualDOI, UnusualDOI
     include("metadata/doi.jl")
+
+    export Study
+    include("study.jl")
+
+    export Record, id, judgements,  location, spec, data, ExtractStudy
+    include("record.jl")
+
+    export RecordDatabase, check_uuid, check_url
+    import Base: UUID
+    include("database.jl")
     
     import Base.convert, Base.==
     export Judgements, J, Judgement, NoJudgement, convert, rating, comment, certainty
@@ -25,12 +35,6 @@ module Taxonomy
     include("judgements/Judgements.jl")
 
     using Taxonomy.Judgements
-
-    export Study
-    include("study.jl")
-
-    export Record, id, judgements,  location, spec, data, ExtractStudy
-    include("record.jl")
 
     import HTTP
     import JSON
@@ -56,10 +60,6 @@ module Taxonomy
     import UUIDs
     export generate_id
     include("uuid.jl")
-
-    export RecordDatabase, check_uuid, check_url
-    import Base: UUID
-    include("database.jl")
 
     export Model
     include("model.jl")

--- a/src/Taxonomy.jl
+++ b/src/Taxonomy.jl
@@ -61,13 +61,13 @@ module Taxonomy
     import Base: UUID
     include("database.jl")
 
+    export Model
+    include("model.jl")
+
     export factor_variance, structural_model, doi
     include("extractors.jl")
 
     include("pretty_printing.jl")
-
-    export Model
-    include("model.jl")
 
     include("deprecated.jl")
 end

--- a/src/Taxonomy.jl
+++ b/src/Taxonomy.jl
@@ -67,6 +67,8 @@ module Taxonomy
     export factor_variance, structural_model, doi
     include("extractors.jl")
 
+    include("filter.jl")
+
     include("pretty_printing.jl")
 
     include("deprecated.jl")

--- a/src/extractors.jl
+++ b/src/extractors.jl
@@ -17,10 +17,7 @@ rating(factor_variance(f))
 1.0
 ```
 """
-function factor_variance(x::Measurement)
-    x.factor_variance
-end
-
+factor_variance(x::Measurement) = x.factor_variance
 
 """
 Function to extract the `StenoGraphs` structural model from [`Structural`].
@@ -47,11 +44,7 @@ struct_model = Structural(structural_model = graph)
 structural_model(struct_model)
 ```
 """
-function structural_model(x::Structural)
-    x.structural_model
-end
-
-
+structural_model(x::Structural) = x.structural_model
 
 """
 Function to extract a Judgement from a `JudgementLevel` (e.g. [Model](@ref), [Record](@ref), [Study](@ref)).
@@ -83,49 +76,30 @@ judgements(x::JudgementLevel) = x.judgements
 url(x::Record) = url(location(x))
 url(x::RecordDatabase) = map(x -> url(x.second), collect(x))
 
-
-function Base.get(r::JudgementLevel, field::Symbol, default=Vector{Union{JudgementLevel, AbstractJudgement}}[])
-    return get(judgements(r), field, default)
-end
-
-
+Base.get(r::JudgementLevel, field::Symbol, default=Vector{Union{JudgementLevel,AbstractJudgement}}[]) = get(judgements(r), field, default)
 
 """
-Extract all studies from a record. 
+Extract all `Studies` from a `Record`. 
 """
-function Study(r::Record)::Vector{Union{Study,AbstractJudgement}}
-    return get(judgements(r), :Study, [])
-
-end
-
-function Study(r::Dict{Symbol, Vector{Union{Study, AbstractJudgement}}})::Vector{Union{Study,AbstractJudgement}}
-    return get(r, :Study, [])
-end
+Study(r::Record)::Vector{Union{Study,AbstractJudgement}} = get(judgements(r), :Study, [])
+Study(r::Dict{Symbol,Vector{Union{Study,AbstractJudgement}}})::Vector{Union{Study,AbstractJudgement}} = get(r, :Study, [])
 
 """
-Extract all models from a Study. 
+Extract all `Models` from a `Study`. 
 """
-function Model(s::Study)::Vector{Union{Model,AbstractJudgement}}
-    return get(judgements(s), :Model, [])
-end
+Model(s::Study)::Vector{Union{Model,AbstractJudgement}} = get(judgements(s), :Model, [])
 
 """
 Extract all Taxons from a Model.
 """
-function Taxon(m::Model)::Vector{Union{Taxon,AbstractJudgement}}
-    return get(judgements(m), :Taxon, [])
-end
+Taxon(m::Model)::Vector{Union{Taxon,AbstractJudgement}} = get(judgements(m), :Taxon, [])
 
 """
 Extract Measurement part from a Taxon. 
 """
-function measurement_model(t::Taxon)
-    return t.measurement_model
-end
+measurement_model(t::Taxon) = t.measurement_model
 
 """
 Extract Structural part from a Taxon. 
 """
-function structural_model(t::Taxon)
-    return t.structural_model
-end
+structural_model(t::Taxon) = t.structural_model

--- a/src/extractors.jl
+++ b/src/extractors.jl
@@ -93,19 +93,19 @@ end
 """
 Extract all studies from a record. 
 """
-function Study(r::Record)::Vector{Union{JudgementLevel,AbstractJudgement}}
+function Study(r::Record)::Vector{Union{Study,AbstractJudgement}}
     return get(judgements(r), :Study, [])
 
 end
 
-function Study(r::Dict{Symbol, Vector{Union{Study, AbstractJudgement}}})::Vector{Union{JudgementLevel,AbstractJudgement}}
+function Study(r::Dict{Symbol, Vector{Union{Study, AbstractJudgement}}})::Vector{Union{Study,AbstractJudgement}}
     return get(r, :Study, [])
 end
 
 """
 Extract all models from a Study. 
 """
-function Model(s::Study)::Vector{Union{JudgementLevel,AbstractJudgement}}
+function Model(s::Study)::Vector{Union{Model,AbstractJudgement}}
     return get(judgements(s), :Model, [])
 end
 

--- a/src/extractors.jl
+++ b/src/extractors.jl
@@ -82,3 +82,27 @@ Dict{Symbol, Vector{Union{Study, AbstractJudgement}}} with 1 entry:
 judgements(x::JudgementLevel) = x.judgements
 url(x::Record) = url(location(x))
 url(x::RecordDatabase) = map(x -> url(x.second), collect(x)) 
+
+
+
+"""
+Extract all studies from a record. 
+"""
+function Study(r::Record)::Vector{Union{JudgementLevel,AbstractJudgement}}
+    if :Study in keys(judgements(r))
+        return judgements(r)[:Study]
+    else
+        return []
+    end
+end
+
+"""
+Extract al models from a Study. 
+"""
+function Model(s::Study)::Vector{Union{JudgementLevel,AbstractJudgement}}
+    if :Model in keys(judgements(s))
+        return judgements(s)[:Model]
+    else
+        return []
+    end
+end

--- a/src/extractors.jl
+++ b/src/extractors.jl
@@ -84,10 +84,10 @@ url(x::Record) = url(location(x))
 url(x::RecordDatabase) = map(x -> url(x.second), collect(x))
 
 
-## Judgements of a specific type are always a vector, so we have to take elements of the vector
 function Base.get(r::JudgementLevel, field::Symbol, default=[])
     return get(judgements(r), field, default)
 end
+
 
 
 """
@@ -107,4 +107,25 @@ Extract all models from a Study.
 """
 function Model(s::Study)::Vector{Union{JudgementLevel,AbstractJudgement}}
     return get(judgements(s), :Model, [])
+end
+
+"""
+Extract all Taxons from a Model.
+"""
+function Taxon(m::Model)::Vector{Union{JudgementLevel,AbstractJudgement}}
+    return get(judgements(m), :Taxon, [])
+end
+
+"""
+Extract Measurement part from a Taxon. 
+"""
+function measurement_model(t::Taxon)
+    return t.measurement_model
+end
+
+"""
+Extract Structural part from a Taxon. 
+"""
+function structural_model(t::Taxon)
+    return t.structural_model
 end

--- a/src/extractors.jl
+++ b/src/extractors.jl
@@ -81,28 +81,27 @@ Dict{Symbol, Vector{Union{Study, AbstractJudgement}}} with 1 entry:
 """
 judgements(x::JudgementLevel) = x.judgements
 url(x::Record) = url(location(x))
-url(x::RecordDatabase) = map(x -> url(x.second), collect(x)) 
+url(x::RecordDatabase) = map(x -> url(x.second), collect(x))
 
+
+## Judgements of a specific type are always a vector, so we have to take elements of the vector
+function Base.get(r::JudgementLevel, field::Symbol, default=[])
+    return get(judgements(r), field, default)
+end
 
 
 """
 Extract all studies from a record. 
 """
 function Study(r::Record)::Vector{Union{JudgementLevel,AbstractJudgement}}
-    if :Study in keys(judgements(r))
-        return judgements(r)[:Study]
-    else
-        return []
-    end
+    return get(judgements(r), :Study, [])
+
 end
 
 """
 Extract al models from a Study. 
 """
 function Model(s::Study)::Vector{Union{JudgementLevel,AbstractJudgement}}
-    if :Model in keys(judgements(s))
-        return judgements(s)[:Model]
-    else
-        return []
-    end
+    return get(judgements(s), :Model, [])
 end
+

--- a/src/extractors.jl
+++ b/src/extractors.jl
@@ -98,10 +98,13 @@ function Study(r::Record)::Vector{Union{JudgementLevel,AbstractJudgement}}
 
 end
 
+function Study(r::Dict{Symbol, Vector{Union{Study, AbstractJudgement}}})::Vector{Union{JudgementLevel,AbstractJudgement}}
+    return get(r, :Study, [])
+end
+
 """
-Extract al models from a Study. 
+Extract all models from a Study. 
 """
 function Model(s::Study)::Vector{Union{JudgementLevel,AbstractJudgement}}
     return get(judgements(s), :Model, [])
 end
-

--- a/src/extractors.jl
+++ b/src/extractors.jl
@@ -84,7 +84,7 @@ url(x::Record) = url(location(x))
 url(x::RecordDatabase) = map(x -> url(x.second), collect(x))
 
 
-function Base.get(r::JudgementLevel, field::Symbol, default=[])
+function Base.get(r::JudgementLevel, field::Symbol, default=Vector{Union{JudgementLevel, AbstractJudgement}}[])
     return get(judgements(r), field, default)
 end
 
@@ -112,7 +112,7 @@ end
 """
 Extract all Taxons from a Model.
 """
-function Taxon(m::Model)::Vector{Union{JudgementLevel,AbstractJudgement}}
+function Taxon(m::Model)::Vector{Union{Taxon,AbstractJudgement}}
     return get(judgements(m), :Taxon, [])
 end
 

--- a/src/filter.jl
+++ b/src/filter.jl
@@ -1,4 +1,3 @@
-
 function Base.filter(f, s::Vector{Union{JudgementLevel,AbstractJudgement}})::Vector{Union{JudgementLevel,AbstractJudgement}}
     res_vec = []
     for i in 1:length(s)
@@ -10,13 +9,20 @@ function Base.filter(f, s::Vector{Union{JudgementLevel,AbstractJudgement}})::Vec
     return res_vec
 end
 
-Base.filter(f, s::JudgementLevel)::Vector{Union{JudgementLevel,AbstractJudgement}} = f(s) ? [s] : []
+Base.filter(f, s::JudgementLevel)::Vector{Union{JudgementLevel, AbstractJudgement}} = f(s) ? [s] : []
 
-function Base.filter(f, db::RecordDatabase, level::JudgementLevel) 
+
+function Base.filter(f, db::RecordDatabase, level::JudgementLevel)::RecordDatabase
+
+    if typeof(level) == Record       
+        db = filter(f, db)
+    end
 
     for record in keys(db)
+
         record_studies = Study(db[record])
 
+     
         if typeof(level) == Study
         judgements(db[record])[:Study] = filter(f, record_studies)
         end

--- a/src/filter.jl
+++ b/src/filter.jl
@@ -22,11 +22,6 @@ end
 
 Base.filter(f, s::JudgementLevel)::Vector{Union{JudgementLevel,AbstractJudgement}} = f(s) ? [s] : []
 
-struct filter_levels 
-end
-
-
-
 function Base.filter(f, db::RecordDatabase, level::AbstractString)::RecordDatabase
 
     @assert level in ["Record", "Study", "Model", "Taxon"] "Invalid level. Choose from 'Record', 'Study', 'Model', 'Taxon'"
@@ -40,21 +35,27 @@ function Base.filter(f, db::RecordDatabase, level::AbstractString)::RecordDataba
         studies = Study(db[current_record])
 
 
-        if typeof(level) == "Study"
+        if level == "Study"
             judgements(db[current_record])[:Study] = filter(f, studies)
 
         else
 
             for current_study in eachindex(studies)
                 models = Model(studies[current_study])
-                if typeof(level) == "Model"
+                if level == "Model"
                     judgements(judgements(db[current_record])[:Study][current_study])[:Model] = filter(f, models)
 
                 else
                     for current_model in eachindex(models)
                         taxons = Taxon(models[current_model])
-                        if typeof(level) == "Taxon"
-                            judgements(Models(Study(db[current_record])[current_study])[current_model])[:Taxon] = filter(f, taxons)
+                        if level == "Taxon"
+                            filtered_taxons = filter(f, taxons)
+
+                            if length(filtered_taxons) > 0
+                                judgements(Model(Study(db[current_record])[current_study])[current_model])[:Taxon] = filtered_taxons
+                            else
+                                delete!(judgements(Model(Study(db[current_record])[current_study])[current_model]), :Taxon)
+                            end
                         end
                     end
                 end

--- a/src/filter.jl
+++ b/src/filter.jl
@@ -1,6 +1,17 @@
-function Base.filter(f, s::Vector{Union{JudgementLevel,AbstractJudgement}})::Vector{Union{JudgementLevel,AbstractJudgement}}
+# function Base.filter(f, s::Vector{Union{JudgementLevel,AbstractJudgement}})::Vector{Union{JudgementLevel,AbstractJudgement}}
+#     res_vec = []
+#     for i in eachindex(s)
+#         if f(s[i])
+#             res_vec = push!(res_vec, s[i])
+#         end
+#     end
+
+#     return res_vec
+# end
+
+function Base.filter(f, s::Vector{Union{T,AbstractJudgement}} where T <: JudgementLevel)
     res_vec = []
-    for i in 1:length(s)
+    for i in eachindex(s)
         if f(s[i])
             res_vec = push!(res_vec, s[i])
         end
@@ -8,6 +19,7 @@ function Base.filter(f, s::Vector{Union{JudgementLevel,AbstractJudgement}})::Vec
 
     return res_vec
 end
+
 
 Base.filter(f, s::JudgementLevel)::Vector{Union{JudgementLevel, AbstractJudgement}} = f(s) ? [s] : []
 

--- a/src/filter.jl
+++ b/src/filter.jl
@@ -9,8 +9,8 @@
 #     return res_vec
 # end
 
-function Base.filter(f, s::Vector{Union{T,AbstractJudgement}} where T <: JudgementLevel)
-    res_vec = []
+function Base.filter(f, s::Vector{Union{T,AbstractJudgement}} where {T<:JudgementLevel})
+    res_vec = eltype(s)[]
     for i in eachindex(s)
         if f(s[i])
             res_vec = push!(res_vec, s[i])
@@ -20,31 +20,52 @@ function Base.filter(f, s::Vector{Union{T,AbstractJudgement}} where T <: Judgeme
     return res_vec
 end
 
+Base.filter(f, s::JudgementLevel)::Vector{Union{JudgementLevel,AbstractJudgement}} = f(s) ? [s] : []
 
-Base.filter(f, s::JudgementLevel)::Vector{Union{JudgementLevel, AbstractJudgement}} = f(s) ? [s] : []
+struct filter_levels 
+end
 
-function Base.filter(f, db::RecordDatabase, level::JudgementLevel)::RecordDatabase
 
-    if typeof(level) == Record       
+
+function Base.filter(f, db::RecordDatabase, level::AbstractString)::RecordDatabase
+
+    @assert level in ["Record", "Study", "Model", "Taxon"] "Invalid level. Choose from 'Record', 'Study', 'Model', 'Taxon'"
+
+    if typeof(level) == "Record"
         db = filter(f, db)
     end
 
-    for record in keys(db)
+    for current_record in keys(db)
 
-        record_studies = Study(db[record])
+        studies = Study(db[current_record])
 
-     
-        if typeof(level) == Study
-        judgements(db[record])[:Study] = filter(f, record_studies)
-        end
 
-        if typeof(level) == Model
-            for j in eachindex(record_studies)
-                judgements(judgements(db[record])[:Study][j])[:Model] = filter(f, Model(record_studies[j]))
+        if typeof(level) == "Study"
+            judgements(db[current_record])[:Study] = filter(f, studies)
+
+        else
+
+            for current_study in eachindex(studies)
+                models = Model(studies[current_study])
+                if typeof(level) == "Model"
+                    judgements(judgements(db[current_record])[:Study][current_study])[:Model] = filter(f, models)
+
+                else
+                    for current_model in eachindex(models)
+                        taxons = Taxon(models[current_model])
+                        if typeof(level) == "Taxon"
+                            judgements(Models(Study(db[current_record])[current_study])[current_model])[:Taxon] = filter(f, taxons)
+                        end
+                    end
+                end
             end
-        end
 
+        end
     end
-return db
+    return db
 
 end
+
+
+
+#                judgements(judgements(r[i])[:Study][j])[:Model] = length(filtered_model) > 0 ? filtered_model : Model(Study(r[i])[j])

--- a/src/filter.jl
+++ b/src/filter.jl
@@ -11,6 +11,76 @@ end
 
 Base.filter(f, s::JudgementLevel)::Vector{Union{JudgementLevel,AbstractJudgement}} = f(s) ? [s] : []
 
+
+"""
+    filter(f, db::RecordDatabase, level::AbstractString)::RecordDatabase
+
+Filter the database at a given nesting level. 
+
+# Arguments
+- `f`: A function returning a boolean value for filtering a dict at the specified level. 
+- `db`: A RecordDatabase object.
+- `level`: The character string of the level at which to filter the database. Possible values are `"Record"`, `"Study"`, `"Model"`, `"Taxon"`.
+
+# Examples
+```jldoctest
+
+## Example just for demonstration, coding is not actually derived from the paper!
+
+using Taxonomy
+using Taxonomy.Judgements
+
+test_db = RecordDatabase()
+
+test_db += Record(
+    rater="NH",
+    id="2a129694-550c-4396-be6f-00507b1dc7ba",
+    location=DOI("10.1007/s10869-019-09648-5"),
+    Lang("en"),
+    Study(
+        N(100, 0.8),
+        Model(Standardized(false),
+            LatentPathmodel(
+                Structural(structural_model=missing),
+                Dict(
+                    :IP => Measurement(n_variables=3, factor_variance=missing, loadings=missing, quest_scale=7),
+                    :IN => Measurement(n_variables=4, factor_variance=missing, loadings=missing, quest_scale=6),
+                    :DN => Measurement(n_variables=3, factor_variance=missing, loadings=missing, quest_scale=7),
+                    :BC => Measurement(n_variables=3, factor_variance=missing, loadings=missing, quest_scale=5),
+                    :IB => Measurement(n_variables=5, factor_variance=missing, loadings=missing, quest_scale=5)
+                )
+            )
+        ),
+        Model(Standardized(true),
+            NoTaxon()
+        )
+    ),
+    Study(
+        N(200, 0.98),
+        Model(Standardized(false),
+        ),
+        Model(Standardized(false))
+    )
+)
+
+## Filtering on Taxon level
+filter_Pathmodel = filter(x -> typeof(x) == NoTaxonEver, test_db, "Taxon")
+Model(Study(filter_Pathmodel[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")])[1])[2]
+
+## Filtering on Model level
+filter_Standardized = filter(x -> rating(x, :Standardized) == true, test_db, "Model")
+Model(Study(filter_Standardized[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")])[1])
+
+## Filtering on Study level
+filter_N = filter(x -> certainty(x, :N) > 0.9, test_db, "Study")
+Study(filter_N[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")])
+
+
+# output
+1-element Vector{Union{Study, AbstractJudgement}}:
+ Study(Dict{Symbol, Vector{Union{JudgementLevel, AbstractJudgement}}}(:N => [N{Int64}(200, 0.98, missing)]))
+```
+"""
 function Base.filter(f, db::RecordDatabase, level::AbstractString)::RecordDatabase
 
     @assert level in ["Record", "Study", "Model", "Taxon"] "Invalid level. Choose from 'Record', 'Study', 'Model', 'Taxon'"
@@ -59,9 +129,4 @@ function Base.filter(f, db::RecordDatabase, level::AbstractString)::RecordDataba
         end
     end
     return db
-
 end
-
-
-
-#                judgements(judgements(r[i])[:Study][j])[:Model] = length(filtered_model) > 0 ? filtered_model : Model(Study(r[i])[j])

--- a/src/filter.jl
+++ b/src/filter.jl
@@ -23,7 +23,7 @@ Filter the database at a given nesting level.
 - `level`: The character string of the level at which to filter the database. Possible values are `"Record"`, `"Study"`, `"Model"`, `"Taxon"`.
 
 # Examples
-```jldoctest
+```jldoctest filter-examples
 
 ## Example just for demonstration, coding is not actually derived from the paper!
 
@@ -67,9 +67,25 @@ test_db += Record(
 filter_Pathmodel = filter(x -> typeof(x) == NoTaxonEver, test_db, "Taxon")
 Model(Study(filter_Pathmodel[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")])[1])[2]
 
+# output
+Model(Dict{Symbol, Vector{Union{Taxon, AbstractJudgement}}}(:Taxon => [NoTaxonEver
+], :Standardized => [Standardized{Bool}(true, 1.0, missing)]))
+```
+
+```jldoctest filter-examples
+
 ## Filtering on Model level
 filter_Standardized = filter(x -> rating(x, :Standardized) == true, test_db, "Model")
 Model(Study(filter_Standardized[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")])[1])
+
+# output
+1-element Vector{Union{Model, AbstractJudgement}}:
+ Model(Dict{Symbol, Vector{Union{Taxon, AbstractJudgement}}}(:Taxon => [NoTaxonEver
+], :Standardized => [Standardized{Bool}(true, 1.0, missing)]))
+
+```
+
+```jldoctest filter-examples
 
 ## Filtering on Study level
 filter_N = filter(x -> certainty(x, :N) > 0.9, test_db, "Study")

--- a/src/filter.jl
+++ b/src/filter.jl
@@ -1,0 +1,33 @@
+
+function Base.filter(f, s::Vector{Union{JudgementLevel,AbstractJudgement}})::Vector{Union{JudgementLevel,AbstractJudgement}}
+    res_vec = []
+    for i in 1:length(s)
+        if f(s[i])
+            res_vec = push!(res_vec, s[i])
+        end
+    end
+
+    return res_vec
+end
+
+Base.filter(f, s::JudgementLevel)::Vector{Union{JudgementLevel,AbstractJudgement}} = f(s) ? [s] : []
+
+function Base.filter(f, db::RecordDatabase, level::JudgementLevel) 
+
+    for record in keys(db)
+        record_studies = Study(db[record])
+
+        if typeof(level) == Study
+        judgements(db[record])[:Study] = filter(f, record_studies)
+        end
+
+        if typeof(level) == Model
+            for j in eachindex(record_studies)
+                judgements(judgements(db[record])[:Study][j])[:Model] = filter(f, Model(record_studies[j]))
+            end
+        end
+
+    end
+return db
+
+end

--- a/src/filter.jl
+++ b/src/filter.jl
@@ -8,9 +8,7 @@ function Base.filter(f, s::Vector{Union{T,AbstractJudgement}} where {T<:Judgemen
 
     return res_vec
 end
-
 Base.filter(f, s::JudgementLevel)::Vector{Union{JudgementLevel,AbstractJudgement}} = f(s) ? [s] : []
-
 
 """
     filter(f, db::RecordDatabase, level::AbstractString)::RecordDatabase
@@ -90,7 +88,6 @@ Model(Study(filter_Standardized[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba"
 ## Filtering on Study level
 filter_N = filter(x -> certainty(x, :N) > 0.9, test_db, "Study")
 Study(filter_N[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")])
-
 
 # output
 1-element Vector{Union{Study, AbstractJudgement}}:

--- a/src/filter.jl
+++ b/src/filter.jl
@@ -11,7 +11,6 @@ end
 
 Base.filter(f, s::JudgementLevel)::Vector{Union{JudgementLevel, AbstractJudgement}} = f(s) ? [s] : []
 
-
 function Base.filter(f, db::RecordDatabase, level::JudgementLevel)::RecordDatabase
 
     if typeof(level) == Record       

--- a/src/judgements/Judgements.jl
+++ b/src/judgements/Judgements.jl
@@ -1,5 +1,5 @@
 module Judgements
-    import Taxonomy: AbstractJudgement, Taxon, JudgementLevel, Record
+    import Taxonomy: AbstractJudgement, Taxon, JudgementLevel, Record, Base.==
     check_certainty(c) = ((c < 0.0) || (c > 1.0)) ? throw(ArgumentError("Certainty must be between 0 and 1.")) : nothing
     export AnyLevelJudgement, RecordJudgement, StudyJudgement, ModelJudgement
     export check_judgement_level, correct_judgement_level, judgements

--- a/src/judgements/Judgements.jl
+++ b/src/judgements/Judgements.jl
@@ -15,6 +15,6 @@ module Judgements
     export judgement_dict
     include("dict.jl")
 
-    export CFI, Empirical, Lang, N, Standardized
+    export CFI, Empirical, Lang, N, Standardized, Quest
     include("predefined_judgements.jl")
 end

--- a/src/judgements/Judgements.jl
+++ b/src/judgements/Judgements.jl
@@ -15,6 +15,6 @@ module Judgements
     export judgement_dict
     include("dict.jl")
 
-    export CFI, Empirical, Lang, N
+    export CFI, Empirical, Lang, N, Standardized
     include("predefined_judgements.jl")
 end

--- a/src/judgements/Judgements.jl
+++ b/src/judgements/Judgements.jl
@@ -6,7 +6,7 @@ module Judgements
     include("level.jl")
 
     export @newjudgement
-    export J, Judgement, NoJudgement, convert, rating, comment, certainty, judgement_key
+    export J, Judgement, NoJudgement, convert, rating, comment, certainty, judgement_key, judgement_level
     include("judgement.jl")
 
     # exports via code gen within the file

--- a/src/judgements/Judgements.jl
+++ b/src/judgements/Judgements.jl
@@ -1,5 +1,5 @@
 module Judgements
-    import Taxonomy: AbstractJudgement, Taxon, JudgementLevel
+    import Taxonomy: AbstractJudgement, Taxon, JudgementLevel, Record
     check_certainty(c) = ((c < 0.0) || (c > 1.0)) ? throw(ArgumentError("Certainty must be between 0 and 1.")) : nothing
     export AnyLevelJudgement, RecordJudgement, StudyJudgement, ModelJudgement
     export check_judgement_level, correct_judgement_level, judgements

--- a/src/judgements/judgement.jl
+++ b/src/judgements/judgement.jl
@@ -63,19 +63,19 @@ macro newjudgement(name, level, doc, type=Any, check=x -> nothing, unique=true)
     unique = :(Judgements.judgement_unique(::$name) = $unique)
     key = :(Judgements.judgement_key(::$name) = Symbol($name))
     level = :(Judgements.judgement_level(::$name) = $level())
-   
+
     # Create a new function with the same name as the judgement
     # This function accepts keyword arguments and creates a NamedTuple
     # The NamedTuple is then passed to the judgement constructor
     keyword_func = quote
-        function $name(;kwargs...)
+        function $name(; kwargs...)
             kwargs_tuple = NamedTuple{tuple(keys(kwargs)...)}(tuple(values(kwargs)...))
             $name(kwargs_tuple)
         end
     end
-        
 
-    
+
+
     return quote
         $(esc(inner))
         $(esc(outer))
@@ -86,7 +86,7 @@ macro newjudgement(name, level, doc, type=Any, check=x -> nothing, unique=true)
         $(esc(doc))
         $(esc(keyword_func))
     end
-    end
+end
 
 @newjudgement(
     Judgement,
@@ -109,11 +109,27 @@ macro newjudgement(name, level, doc, type=Any, check=x -> nothing, unique=true)
 """
 Extract rating from Judgement.
 
-If `rating` is called on a `Judgement` it returns the rating, on everything it returns identity.
+If `rating` is called on a `Judgement` it returns the rating, on everything it returns identity. 
+If `rating` is called on a `JudgementLevel` together with a field name, it returns the rating of that field. 
 
 """
 rating(x) = x
 rating(x::AbstractJudgement) = x.rating
+rating(x::JudgementLevel, field::Symbol) = rating(get(x, field))
+function rating(x::Union{Vector{Union{Taxon, AbstractJudgement}}, Vector{Union{JudgementLevel, AbstractJudgement}} })
+    if Base.:(==)(length(x), 1)
+        return rating(x[1])
+    elseif Base.:(==)(length(x), 0)
+        return x
+    else
+        error("Currently only ratings of single Judgements are supported.")
+        # res_vec = []
+        # for i in x 
+        #     push!(res_vec, rating(i))
+        # end
+        # return res_vec
+    end
+end
 
 """
 Extract certainty from Judgement.

--- a/src/judgements/judgement.jl
+++ b/src/judgements/judgement.jl
@@ -117,18 +117,18 @@ rating(x) = x
 rating(x::AbstractJudgement) = x.rating
 rating(x::JudgementLevel, field::Symbol) = rating(get(x, field))
 rating(x::Pair{Base.UUID, Record}, field::Symbol) = rating(x.second, field)
-function rating(x::Union{Vector{Union{T,AbstractJudgement}}}) where T <: JudgementLevel
+function rating(x::Vector{Union{T,AbstractJudgement}}) where T <: JudgementLevel
     if Base.:(==)(length(x), 1)
         return rating(x[1])
     elseif Base.:(==)(length(x), 0)
         return x
     else
-        error("Currently only ratings of single Judgements are supported.")
-        # res_vec = []
-        # for i in x 
-        #     push!(res_vec, rating(i))
-        # end
-        # return res_vec
+#        error("Currently only ratings of single Judgements are supported.")
+        res_vec = []
+        for i in x 
+            push!(res_vec, rating(i))
+        end
+        return res_vec
     end
 end
 

--- a/src/judgements/judgement.jl
+++ b/src/judgements/judgement.jl
@@ -136,6 +136,21 @@ end
 Extract certainty from Judgement.
 """
 certainty(x::AbstractJudgement) = x.certainty
+certainty(x::JudgementLevel, field::Symbol) = certainty(get(x, field))
+function certainty(x::Vector{Union{T,AbstractJudgement}}) where T <: JudgementLevel
+    if Base.:(==)(length(x), 1)
+        return certainty(x[1])
+    elseif Base.:(==)(length(x), 0)
+        return x
+    else
+#        error("Currently only certainty of single Judgements is supported.")
+        res_vec = []
+        for i in x 
+            push!(res_vec, certainty(i))
+        end
+        return res_vec
+    end
+end
 
 """
 Extract comment from Judgement.

--- a/src/judgements/judgement.jl
+++ b/src/judgements/judgement.jl
@@ -136,6 +136,7 @@ end
 Extract certainty from Judgement.
 """
 certainty(x::AbstractJudgement) = x.certainty
+certainty(x::Pair{Base.UUID, Record}, field::Symbol) = certainty(x.second, field)
 certainty(x::JudgementLevel, field::Symbol) = certainty(get(x, field))
 function certainty(x::Vector{Union{T,AbstractJudgement}}) where T <: JudgementLevel
     if Base.:(==)(length(x), 1)

--- a/src/judgements/judgement.jl
+++ b/src/judgements/judgement.jl
@@ -116,7 +116,8 @@ If `rating` is called on a `JudgementLevel` together with a field name, it retur
 rating(x) = x
 rating(x::AbstractJudgement) = x.rating
 rating(x::JudgementLevel, field::Symbol) = rating(get(x, field))
-function rating(x::Union{Vector{Union{Taxon,AbstractJudgement}},Vector{Union{JudgementLevel,AbstractJudgement}}})
+rating(x::Pair{Base.UUID, Record}, field::Symbol) = rating(x.second, field)
+function rating(x::Union{Vector{Union{T,AbstractJudgement}}}) where T <: JudgementLevel
     if Base.:(==)(length(x), 1)
         return rating(x[1])
     elseif Base.:(==)(length(x), 0)

--- a/src/judgements/judgement.jl
+++ b/src/judgements/judgement.jl
@@ -118,17 +118,12 @@ rating(x::AbstractJudgement) = x.rating
 rating(x::JudgementLevel, field::Symbol) = rating(get(x, field))
 rating(x::Pair{Base.UUID, Record}, field::Symbol) = rating(x.second, field)
 function rating(x::Vector{Union{T,AbstractJudgement}}) where T <: JudgementLevel
-    if Base.:(==)(length(x), 1)
+    if length(x) == 1
         return rating(x[1])
-    elseif Base.:(==)(length(x), 0)
+    elseif length(x) == 0
         return x
     else
-#        error("Currently only ratings of single Judgements are supported.")
-        res_vec = []
-        for i in x 
-            push!(res_vec, rating(i))
-        end
-        return res_vec
+        error("It seems like you have provided a vector that contains multiple judgements. Only the rating of single judgement can be extracted.")
     end
 end
 
@@ -139,17 +134,12 @@ certainty(x::AbstractJudgement) = x.certainty
 certainty(x::Pair{Base.UUID, Record}, field::Symbol) = certainty(x.second, field)
 certainty(x::JudgementLevel, field::Symbol) = certainty(get(x, field))
 function certainty(x::Vector{Union{T,AbstractJudgement}}) where T <: JudgementLevel
-    if Base.:(==)(length(x), 1)
+    if length(x) == 1
         return certainty(x[1])
-    elseif Base.:(==)(length(x), 0)
+    elseif length(x) == 0
         return x
     else
-#        error("Currently only certainty of single Judgements is supported.")
-        res_vec = []
-        for i in x 
-            push!(res_vec, certainty(i))
-        end
-        return res_vec
+        error("It seems like you have provided a vector that contains multiple judgements. Only the certainty of single judgement can be extracted.")
     end
 end
 

--- a/src/judgements/judgement.jl
+++ b/src/judgements/judgement.jl
@@ -116,7 +116,7 @@ If `rating` is called on a `JudgementLevel` together with a field name, it retur
 rating(x) = x
 rating(x::AbstractJudgement) = x.rating
 rating(x::JudgementLevel, field::Symbol) = rating(get(x, field))
-function rating(x::Union{Vector{Union{Taxon, AbstractJudgement}}, Vector{Union{JudgementLevel, AbstractJudgement}} })
+function rating(x::Union{Vector{Union{Taxon,AbstractJudgement}},Vector{Union{JudgementLevel,AbstractJudgement}}})
     if Base.:(==)(length(x), 1)
         return rating(x[1])
     elseif Base.:(==)(length(x), 0)

--- a/src/judgements/judgement.jl
+++ b/src/judgements/judgement.jl
@@ -129,6 +129,10 @@ end
 
 """
 Extract certainty from Judgement.
+
+If `certainty` is called on a `Judgement` it returns the certainty, on everything it returns identity. 
+If `certainty` is called on a `JudgementLevel` together with a field name, it returns the certainty of that field. 
+
 """
 certainty(x::AbstractJudgement) = x.certainty
 certainty(x::Pair{Base.UUID, Record}, field::Symbol) = certainty(x.second, field)

--- a/src/judgements/predefined_judgements.jl
+++ b/src/judgements/predefined_judgements.jl
@@ -72,3 +72,22 @@ Judgement for N.
     """,
     Bool # Input type. In this case boolean.
 )
+
+@newjudgement(
+    Quest,
+    ModelJudgement,
+    """
+    What questionnaire was used to measure the latent variable.
+    
+    Procedure:
+    * Look for first instance of questionnaire, 
+    * acronym or name is fine, copy and paste citation if availible
+    * Do not bother whether the scale is translated, modified or shortened.
+    * spend little time (<30s) on searching for it
+    * should be given multiple times for all quests present in a model.
+
+    """,
+    AbstractString,
+    x -> nothing,
+    unique = false
+)

--- a/src/judgements/predefined_judgements.jl
+++ b/src/judgements/predefined_judgements.jl
@@ -60,4 +60,15 @@ Judgement for N.
     Int # Input type. In this case Integer. 
 )
 
+@newjudgement(
+    Standardized,
+    ModelJudgement,  
+    """
+    Any part of the data or model is standardized
 
+    Procedure:
+    * Search for standard*
+    * If present, give True
+    """,
+    Bool # Input type. In this case boolean.
+)

--- a/test/extractors.jl
+++ b/test/extractors.jl
@@ -1,272 +1,132 @@
-# @testset "factor_variance" begin
-#     measurement = Measurement(n_variables=2, loadings=[1, 0.4], factor_variance=1.0)
-#     standalone_factor = StandaloneFactor(n_variables=2, loadings=[0.1, 0.2], factor_variance=0.5)
+@testset "factor_variance" begin
+    measurement = Measurement(n_variables=2, loadings=[1, 0.4], factor_variance=1.0)
+    standalone_factor = StandaloneFactor(n_variables=2, loadings=[0.1, 0.2], factor_variance=0.5)
 
-#     @test rating(factor_variance(measurement)) == 1.0
-#     @test rating(factor_variance(standalone_factor)) == 0.5
-# end
+    @test rating(factor_variance(measurement)) == 1.0
+    @test rating(factor_variance(standalone_factor)) == 0.5
+end
 
-# @testset "extract studies" begin
+@testset "extract studies" begin
 
-#     test_record_1 = Record(
-#         rater="NH",
-#         id="2a129694-550c-4396-be6f-00507b1dc7bb",
-#         Lang("en"),
-#         Study(
-#             N(100),
-#             Model(
-#                 Standardized(true)
-#             )
-#         )
-#     )
-
-#     @test typeof(Study(test_record_1)) == Vector{Union{JudgementLevel,AbstractJudgement}}
-#     @test length(Study(test_record_1)) == 1
-#     @test rating(Study(judgements(test_record_1))[1], :N) == 100
-
-#     test_record_2 = Record(
-#         rater="NH",
-#         id="2a129694-550c-4396-be6f-00507b1dc7bb",
-#         Lang("en"),
-#         Study(
-#             N(100),
-#             Model(
-#                 Standardized(true)
-#             )
-#         ),
-#         Study(
-#             N(200),
-#             Model(
-#                 Standardized(false)
-#             )
-#         )
-#     )
-
-#     @test typeof(Study(test_record_2)) == Vector{Union{JudgementLevel,AbstractJudgement}}
-#     @test length(Study(test_record_2)) == 2
-
-
-#     test_record_0 = Record(
-#         rater="NH",
-#         id="2a129694-550c-4396-be6f-00507b1dc7bb",
-#         Lang("en")
-#     )
-
-#     @test typeof(Study(test_record_0)) == Vector{Union{JudgementLevel,AbstractJudgement}}
-#     @test length(Study(test_record_0)) == 0
-#     @test length(Study(judgements(test_record_0))) == 0
-
-# end
-
-
-# @testset "extract models" begin
-#     test_study_1 = Study(
-#         N(100),
-#         Model(
-#             Standardized(true)
-#         )
-#     )
-
-#     @test typeof(Model(test_study_1)) == Vector{Union{JudgementLevel,AbstractJudgement}}
-#     @test length(Model(test_study_1)) == 1
-
-#     test_study_2 = Study(
-#         N(100),
-#         Model(
-#             Standardized(true)
-#         ),
-#         Model(
-#             Standardized(false)
-#         )
-#     )
-
-
-#     @test typeof(Model(test_study_2)) == Vector{Union{JudgementLevel,AbstractJudgement}}
-#     @test length(Model(test_study_2)) == 2
-
-#     test_study_0 = Study(
-#         N(100)
-#     )
-
-#     @test typeof(Model(test_study_0)) == Vector{Union{JudgementLevel,AbstractJudgement}}
-#     @test length(Model(test_study_0)) == 0
-# end
-
-# @testset "get for JudgementLevel" begin
-#     @test get(Study(N(100)), :N)[1] == N(100)
-#     @test get(Study(N(100)), :Z) == []
-# end
-
-
-#@testset "extract Taxons" begin
-#     test_model = Model(Standardized(true),
-#         LatentPathmodel(
-#             Structural(structural_model=missing),
-#             Dict(
-#                 :IP => Measurement(n_variables=3, factor_variance=missing, loadings=missing, quest_scale=7),
-#                 :IN => Measurement(n_variables=4, factor_variance=missing, loadings=missing, quest_scale=6),
-#                 :DN => Measurement(n_variables=3, factor_variance=missing, loadings=missing, quest_scale=7),
-#                 :BC => Measurement(n_variables=3, factor_variance=missing, loadings=missing, quest_scale=5),
-#                 :IB => Measurement(n_variables=5, factor_variance=missing, loadings=missing, quest_scale=5)
-#             )
-#         ),
-#         LatentPathmodel(
-#             Structural(structural_model=missing),
-#             Dict(
-#                 :IP => Measurement(n_variables=3, factor_variance=missing, loadings=missing, quest_scale=7),
-#                 :IN => Measurement(n_variables=4, factor_variance=missing, loadings=missing, quest_scale=6),
-#                 :DN => Measurement(n_variables=3, factor_variance=missing, loadings=missing, quest_scale=7),
-#                 :BC => Measurement(n_variables=3, factor_variance=missing, loadings=missing, quest_scale=5),
-#                 :IB => Measurement(n_variables=5, factor_variance=missing, loadings=missing, quest_scale=5)
-#             )
-#         )
-#     )
-
-#     @test typeof(Taxon(test_model)[1]) == LatentPathmodel
-#     @test length(Taxon(test_model)) == 2
-# end
-
-#@testset "extract measurement_model" begin
-  
-    using Taxonomy
-    using Taxonomy.Judgements
-
-    db = RecordDatabase()
-
-    test_record = Record(
-        rater="VK",
-        id="2a129694-550c-4396-be6f-00507b1dc7ba",
+    test_record_1 = Record(
+        rater="NH",
+        id="2a129694-550c-4396-be6f-00507b1dc7bb",
         Lang("en"),
         Study(
             N(100),
-            Model(Standardized(true), 
-            LatentPathmodel(
-                Structural(structural_model = missing ),
-                Dict(
-                    :IP => Measurement(n_variables = 3, factor_variance = missing, loadings = missing, quest_scale = 7),
-                    :IN => Measurement(n_variables = 4, factor_variance = missing, loadings = missing, quest_scale = 6),
-                    :DN => Measurement(n_variables = 3, factor_variance = missing, loadings = missing, quest_scale = 7),
-                    :BC => Measurement(n_variables = 3, factor_variance = missing, loadings = missing, quest_scale = 5),
-                    :IB => Measurement(n_variables = 5, factor_variance = missing, loadings = missing, quest_scale = 5)
-                )
-            )),
-            Model(Standardized(false))
-        ), 
-        Study(N(120))
+            Model(
+                Standardized(true)
+            )
+        )
     )
 
-    db += test_record
+    @test typeof(Study(test_record_1)) == Vector{Union{Study,AbstractJudgement}}
+    @test length(Study(test_record_1)) == 1
+    @test rating(Study(judgements(test_record_1))[1], :N) == 100
+
+    test_record_2 = Record(
+        rater="NH",
+        id="2a129694-550c-4396-be6f-00507b1dc7bb",
+        Lang("en"),
+        Study(
+            N(100),
+            Model(
+                Standardized(true)
+            )
+        ),
+        Study(
+            N(200),
+            Model(
+                Standardized(false)
+            )
+        )
+    )
+
+    @test typeof(Study(test_record_2)) == Vector{Union{Study,AbstractJudgement}}
+    @test length(Study(test_record_2)) == 2
 
 
+    test_record_0 = Record(
+        rater="NH",
+        id="2a129694-550c-4396-be6f-00507b1dc7bb",
+        Lang("en")
+    )
 
+    @test typeof(Study(test_record_0)) == Vector{Union{Study,AbstractJudgement}}
+    @test length(Study(test_record_0)) == 0
+    @test length(Study(judgements(test_record_0))) == 0
 
-
-## 1) Go through all Records of a Database.
-## 2) Depending on the JudgementLevel, either loop over Studies or Models. This is done automatically by the filter function. So what I need to figure out is
-## how to provide the filter function with the correct JudgementLevel - Vector.
-## Two option of defining Study in the filter-function:
-
-####################################################################
-## Option A 
-####################################################################
-#Within the function.
-
-## 1) Ok, so now I have to loop over the single records. 
-## 2) Then I have to extract the Study-Vector from each record. Not a Problem!
-## 3) Now I have a Vector of Studys. Here get fails, because it only makes sense for one dict!
-## 4) I could try to make it work with a vector of Boolean values: It has the same length as Study-Vector and selects only those Studies that the condition 
-##    is met for:
-
-## Define return types::!
-# Base.get(x::Vector{Union{T,AbstractJudgement}} where T <: JudgementLevel, key::Symbol) = [get(x[i], key) for i in eachindex(x)]
-# function Taxonomy.rating(x::Vector{Vector{Union{JudgementLevel,AbstractJudgement}}}) 
-#     res_vec = []
-#     for i in eachindex(x) ## Deal with different cases here!
-#         push!(res_vec, rating(x[i][1]))
-#     end
-    
-#     return res_vec
-# end
-
-# function Base.filter(f, r::RecordDatabase)
-
-#     for i in keys(r)
-
-#         judgements(r[i])[:Study] = Study(r[i])[f(r[i])]
-
-#     end
-
-#     return r
-# end
-
-# ## Go through all levels and try the function, use the results if it works and dont if it doesnt. Maybe return a default value if the field is not found?
-
-
-# filter(x -> rating(get(Study(x), :N)) .== 100, db)
-
-# Study(db[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")])
-
-
-# ## Here the problem arises that I have to loop over the study vec first to extract the models for each study.  
-# filter(x -> rating(get(Model(Study(x), :Standardized)) .== true, db))
-# Study(db[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")])
-
-## tryout --------:
-
-
-
-
-####################################################################
-## Option B:
-####################################################################
-## Define JudgementLevel in the second argument!
-
-
-
-## Doesnt make sense because this would mean we don't provide the full database, but only the STudies ...
-## But what if we loop over the database, try Study(), Model() etc. for the second argument and see if f() returns something sensible?
-
-function Base.filter(f, s::Vector{Union{T,AbstractJudgement}} where T <: JudgementLevel)
-    res_vec = eltype(s)[]
-for i in eachindex(s)
-    if f(s[i])
-        res_vec = push!(res_vec, s[i])
-    end
-end
-
-return res_vec
 end
 
 
+@testset "extract models" begin
+    test_study_1 = Study(
+        N(100),
+        Model(
+            Standardized(true)
+        )
+    )
+
+    @test typeof(Model(test_study_1)) == Vector{Union{Model,AbstractJudgement}}
+    @test length(Model(test_study_1)) == 1
+
+    test_study_2 = Study(
+        N(100),
+        Model(
+            Standardized(true)
+        ),
+        Model(
+            Standardized(false)
+        )
+    )
 
 
-function Base.filter(f, r::RecordDatabase)
+    @test typeof(Model(test_study_2)) == Vector{Union{Model,AbstractJudgement}}
+    @test length(Model(test_study_2)) == 2
 
-    for i in keys(r)
+    test_study_0 = Study(
+        N(100)
+    )
 
-       judgements(r[i])[:Study] = filter(f, Study(r[i]))
-
-        for j in eachindex(Study(r[i]))
-
-            filtered_model = filter(f, Model(Study(r[i])[j]))
-           judgements(judgements(r[i])[:Study][j])[:Model] = length(filtered_model) > 0 ? filtered_model : Model(Study(r[i])[j])
-
-        end
-        
-    end
-
-    return r
+    @test typeof(Model(test_study_0)) == Vector{Union{Model,AbstractJudgement}}
+    @test length(Model(test_study_0)) == 0
 end
 
-filter(z -> rating(get(z, :N)) == 100, db)
-Study(db[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")])
+@testset "get for JudgementLevel" begin
+    @test get(Study(N(100)), :N)[1] == N(100)
+    @test get(Study(N(100)), :Z) == Vector{Union{JudgementLevel, AbstractJudgement}}[]
+end
 
-## Yaaay, this actually worked. Clean up now and try with edge cases and TAxons. 
 
-# filter(z -> rating(get(z, :Lang)) == "en", test_record)
-# filter(z -> rating(get(z, :N)) == 100, Study(test_record))
-# filter(z -> rating(get(z, :Standardized)) == true, Model(Study(test_record)[1]))
+@testset "extract Taxons" begin
+    test_model = Model(Standardized(true),
+        LatentPathmodel(
+            Structural(structural_model=missing),
+            Dict(
+                :IP => Measurement(n_variables=3, factor_variance=missing, loadings=missing, quest_scale=7),
+                :IN => Measurement(n_variables=4, factor_variance=missing, loadings=missing, quest_scale=6),
+                :DN => Measurement(n_variables=3, factor_variance=missing, loadings=missing, quest_scale=7),
+                :BC => Measurement(n_variables=3, factor_variance=missing, loadings=missing, quest_scale=5),
+                :IB => Measurement(n_variables=5, factor_variance=missing, loadings=missing, quest_scale=5)
+            )
+        ),
+        LatentPathmodel(
+            Structural(structural_model=missing),
+            Dict(
+                :IP => Measurement(n_variables=3, factor_variance=missing, loadings=missing, quest_scale=7),
+                :IN => Measurement(n_variables=4, factor_variance=missing, loadings=missing, quest_scale=6),
+                :DN => Measurement(n_variables=3, factor_variance=missing, loadings=missing, quest_scale=7),
+                :BC => Measurement(n_variables=3, factor_variance=missing, loadings=missing, quest_scale=5),
+                :IB => Measurement(n_variables=5, factor_variance=missing, loadings=missing, quest_scale=5)
+            )
+        )
+    )
 
+    @test typeof(Taxon(test_model)[1]) == LatentPathmodel
+    @test length(Taxon(test_model)) == 2
+end
+
+@testset "extract measurement_model" begin
 
 
 

--- a/test/extractors.jl
+++ b/test/extractors.jl
@@ -89,3 +89,8 @@ end
     @test typeof(Model(test_study_0)) == Vector{Union{JudgementLevel,AbstractJudgement}}
     @test length(Model(test_study_0)) == 0
 end
+
+@testset "get for JudgementLevel" begin
+    @test get(Study(N(100)), :N)[1] == N(100)
+    @test get(Study(N(100)), :Z) == []
+end

--- a/test/extractors.jl
+++ b/test/extractors.jl
@@ -126,8 +126,4 @@ end
     @test length(Taxon(test_model)) == 2
 end
 
-@testset "extract measurement_model" begin
-
-
-
 

--- a/test/extractors.jl
+++ b/test/extractors.jl
@@ -1,133 +1,137 @@
-@testset "factor_variance" begin
-    measurement = Measurement(n_variables=2, loadings=[1, 0.4], factor_variance=1.0)
-    standalone_factor = StandaloneFactor(n_variables=2, loadings=[0.1, 0.2], factor_variance=0.5)
+# @testset "factor_variance" begin
+#     measurement = Measurement(n_variables=2, loadings=[1, 0.4], factor_variance=1.0)
+#     standalone_factor = StandaloneFactor(n_variables=2, loadings=[0.1, 0.2], factor_variance=0.5)
 
-    @test rating(factor_variance(measurement)) == 1.0
-    @test rating(factor_variance(standalone_factor)) == 0.5
-end
+#     @test rating(factor_variance(measurement)) == 1.0
+#     @test rating(factor_variance(standalone_factor)) == 0.5
+# end
 
-@testset "extract studies" begin
+# @testset "extract studies" begin
 
-    test_record_1 = Record(
-        rater="NH",
-        id="2a129694-550c-4396-be6f-00507b1dc7bb",
-        Lang("en"),
-        Study(
-            N(100),
-            Model(
-                Standardized(true)
-            )
-        )
-    )
+#     test_record_1 = Record(
+#         rater="NH",
+#         id="2a129694-550c-4396-be6f-00507b1dc7bb",
+#         Lang("en"),
+#         Study(
+#             N(100),
+#             Model(
+#                 Standardized(true)
+#             )
+#         )
+#     )
 
-    @test typeof(Study(test_record_1)) == Vector{Union{JudgementLevel,AbstractJudgement}}
-    @test length(Study(test_record_1)) == 1
-    @test rating(Study(judgements(test_record_1))[1], :N) == 100
+#     @test typeof(Study(test_record_1)) == Vector{Union{JudgementLevel,AbstractJudgement}}
+#     @test length(Study(test_record_1)) == 1
+#     @test rating(Study(judgements(test_record_1))[1], :N) == 100
 
-    test_record_2 = Record(
-        rater="NH",
-        id="2a129694-550c-4396-be6f-00507b1dc7bb",
-        Lang("en"),
-        Study(
-            N(100),
-            Model(
-                Standardized(true)
-            )
-        ),
-        Study(
-            N(200),
-            Model(
-                Standardized(false)
-            )
-        )
-    )
+#     test_record_2 = Record(
+#         rater="NH",
+#         id="2a129694-550c-4396-be6f-00507b1dc7bb",
+#         Lang("en"),
+#         Study(
+#             N(100),
+#             Model(
+#                 Standardized(true)
+#             )
+#         ),
+#         Study(
+#             N(200),
+#             Model(
+#                 Standardized(false)
+#             )
+#         )
+#     )
 
-    @test typeof(Study(test_record_2)) == Vector{Union{JudgementLevel,AbstractJudgement}}
-    @test length(Study(test_record_2)) == 2
-
-
-    test_record_0 = Record(
-        rater="NH",
-        id="2a129694-550c-4396-be6f-00507b1dc7bb",
-        Lang("en")
-    )
-
-    @test typeof(Study(test_record_0)) == Vector{Union{JudgementLevel,AbstractJudgement}}
-    @test length(Study(test_record_0)) == 0
-    @test length(Study(judgements(test_record_0))) == 0
-
-end
+#     @test typeof(Study(test_record_2)) == Vector{Union{JudgementLevel,AbstractJudgement}}
+#     @test length(Study(test_record_2)) == 2
 
 
-@testset "extract models" begin
-    test_study_1 = Study(
-        N(100),
-        Model(
-            Standardized(true)
-        )
-    )
+#     test_record_0 = Record(
+#         rater="NH",
+#         id="2a129694-550c-4396-be6f-00507b1dc7bb",
+#         Lang("en")
+#     )
 
-    @test typeof(Model(test_study_1)) == Vector{Union{JudgementLevel,AbstractJudgement}}
-    @test length(Model(test_study_1)) == 1
+#     @test typeof(Study(test_record_0)) == Vector{Union{JudgementLevel,AbstractJudgement}}
+#     @test length(Study(test_record_0)) == 0
+#     @test length(Study(judgements(test_record_0))) == 0
 
-    test_study_2 = Study(
-        N(100),
-        Model(
-            Standardized(true)
-        ),
-        Model(
-            Standardized(false)
-        )
-    )
+# end
 
 
-    @test typeof(Model(test_study_2)) == Vector{Union{JudgementLevel,AbstractJudgement}}
-    @test length(Model(test_study_2)) == 2
+# @testset "extract models" begin
+#     test_study_1 = Study(
+#         N(100),
+#         Model(
+#             Standardized(true)
+#         )
+#     )
 
-    test_study_0 = Study(
-        N(100)
-    )
+#     @test typeof(Model(test_study_1)) == Vector{Union{JudgementLevel,AbstractJudgement}}
+#     @test length(Model(test_study_1)) == 1
 
-    @test typeof(Model(test_study_0)) == Vector{Union{JudgementLevel,AbstractJudgement}}
-    @test length(Model(test_study_0)) == 0
-end
+#     test_study_2 = Study(
+#         N(100),
+#         Model(
+#             Standardized(true)
+#         ),
+#         Model(
+#             Standardized(false)
+#         )
+#     )
 
-@testset "get for JudgementLevel" begin
-    @test get(Study(N(100)), :N)[1] == N(100)
-    @test get(Study(N(100)), :Z) == []
-end
+
+#     @test typeof(Model(test_study_2)) == Vector{Union{JudgementLevel,AbstractJudgement}}
+#     @test length(Model(test_study_2)) == 2
+
+#     test_study_0 = Study(
+#         N(100)
+#     )
+
+#     @test typeof(Model(test_study_0)) == Vector{Union{JudgementLevel,AbstractJudgement}}
+#     @test length(Model(test_study_0)) == 0
+# end
+
+# @testset "get for JudgementLevel" begin
+#     @test get(Study(N(100)), :N)[1] == N(100)
+#     @test get(Study(N(100)), :Z) == []
+# end
 
 
-@testset "extract Taxons" begin
-    test_model = Model(Standardized(true),
-        LatentPathmodel(
-            Structural(structural_model=missing),
-            Dict(
-                :IP => Measurement(n_variables=3, factor_variance=missing, loadings=missing, quest_scale=7),
-                :IN => Measurement(n_variables=4, factor_variance=missing, loadings=missing, quest_scale=6),
-                :DN => Measurement(n_variables=3, factor_variance=missing, loadings=missing, quest_scale=7),
-                :BC => Measurement(n_variables=3, factor_variance=missing, loadings=missing, quest_scale=5),
-                :IB => Measurement(n_variables=5, factor_variance=missing, loadings=missing, quest_scale=5)
-            )
-        ),
-        LatentPathmodel(
-            Structural(structural_model=missing),
-            Dict(
-                :IP => Measurement(n_variables=3, factor_variance=missing, loadings=missing, quest_scale=7),
-                :IN => Measurement(n_variables=4, factor_variance=missing, loadings=missing, quest_scale=6),
-                :DN => Measurement(n_variables=3, factor_variance=missing, loadings=missing, quest_scale=7),
-                :BC => Measurement(n_variables=3, factor_variance=missing, loadings=missing, quest_scale=5),
-                :IB => Measurement(n_variables=5, factor_variance=missing, loadings=missing, quest_scale=5)
-            )
-        )
-    )
+#@testset "extract Taxons" begin
+#     test_model = Model(Standardized(true),
+#         LatentPathmodel(
+#             Structural(structural_model=missing),
+#             Dict(
+#                 :IP => Measurement(n_variables=3, factor_variance=missing, loadings=missing, quest_scale=7),
+#                 :IN => Measurement(n_variables=4, factor_variance=missing, loadings=missing, quest_scale=6),
+#                 :DN => Measurement(n_variables=3, factor_variance=missing, loadings=missing, quest_scale=7),
+#                 :BC => Measurement(n_variables=3, factor_variance=missing, loadings=missing, quest_scale=5),
+#                 :IB => Measurement(n_variables=5, factor_variance=missing, loadings=missing, quest_scale=5)
+#             )
+#         ),
+#         LatentPathmodel(
+#             Structural(structural_model=missing),
+#             Dict(
+#                 :IP => Measurement(n_variables=3, factor_variance=missing, loadings=missing, quest_scale=7),
+#                 :IN => Measurement(n_variables=4, factor_variance=missing, loadings=missing, quest_scale=6),
+#                 :DN => Measurement(n_variables=3, factor_variance=missing, loadings=missing, quest_scale=7),
+#                 :BC => Measurement(n_variables=3, factor_variance=missing, loadings=missing, quest_scale=5),
+#                 :IB => Measurement(n_variables=5, factor_variance=missing, loadings=missing, quest_scale=5)
+#             )
+#         )
+#     )
 
-    @test typeof(Taxon(test_model)[1]) == LatentPathmodel
-    @test length(Taxon(test_model)) == 2
-end
+#     @test typeof(Taxon(test_model)[1]) == LatentPathmodel
+#     @test length(Taxon(test_model)) == 2
+# end
 
-@testset "extract measurement_model" begin
-    
+#@testset "extract measurement_model" begin
+  
+    using Taxonomy
+    using Taxonomy.Judgements
+
+    db = RecordDatabase()
 
     test_record = Record(
         rater="VK",
@@ -151,97 +155,119 @@ end
         Study(N(120))
     )
 
+    db += test_record
 
 
-f = x -> get(Model(Study(x)), :Standardized)[1] == true
 
-## Define for vectors
-s = Study(test_record)
 
-function Model(s::Vector{Union{JudgementLevel, AbstractJudgement}})
-res_vec = []
+
+## 1) Go through all Records of a Database.
+## 2) Depending on the JudgementLevel, either loop over Studies or Models. This is done automatically by the filter function. So what I need to figure out is
+## how to provide the filter function with the correct JudgementLevel - Vector.
+## Two option of defining Study in the filter-function:
+
+####################################################################
+## Option A 
+####################################################################
+#Within the function.
+
+## 1) Ok, so now I have to loop over the single records. 
+## 2) Then I have to extract the Study-Vector from each record. Not a Problem!
+## 3) Now I have a Vector of Studys. Here get fails, because it only makes sense for one dict!
+## 4) I could try to make it work with a vector of Boolean values: It has the same length as Study-Vector and selects only those Studies that the condition 
+##    is met for:
+
+## Define return types::!
+# Base.get(x::Vector{Union{T,AbstractJudgement}} where T <: JudgementLevel, key::Symbol) = [get(x[i], key) for i in eachindex(x)]
+# function Taxonomy.rating(x::Vector{Vector{Union{JudgementLevel,AbstractJudgement}}}) 
+#     res_vec = []
+#     for i in eachindex(x) ## Deal with different cases here!
+#         push!(res_vec, rating(x[i][1]))
+#     end
+    
+#     return res_vec
+# end
+
+# function Base.filter(f, r::RecordDatabase)
+
+#     for i in keys(r)
+
+#         judgements(r[i])[:Study] = Study(r[i])[f(r[i])]
+
+#     end
+
+#     return r
+# end
+
+# ## Go through all levels and try the function, use the results if it works and dont if it doesnt. Maybe return a default value if the field is not found?
+
+
+# filter(x -> rating(get(Study(x), :N)) .== 100, db)
+
+# Study(db[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")])
+
+
+# ## Here the problem arises that I have to loop over the study vec first to extract the models for each study.  
+# filter(x -> rating(get(Model(Study(x), :Standardized)) .== true, db))
+# Study(db[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")])
+
+## tryout --------:
+
+
+
+
+####################################################################
+## Option B:
+####################################################################
+## Define JudgementLevel in the second argument!
+
+
+
+## Doesnt make sense because this would mean we don't provide the full database, but only the STudies ...
+## But what if we loop over the database, try Study(), Model() etc. for the second argument and see if f() returns something sensible?
+
+function Base.filter(f, s::Vector{Union{T,AbstractJudgement}} where T <: JudgementLevel)
+    res_vec = eltype(s)[]
 for i in eachindex(s)
-    push!(res_vec, Model(s[i]))
+    if f(s[i])
+        res_vec = push!(res_vec, s[i])
+    end
 end
 
 return res_vec
 end
 
-Model(s)
 
-## Or
 
-macro remove_model(expr)
-    if isa(expr, Expr) && expr.head == :call && expr.args[1] == :Model
-        return esc(expr.args[2])
-    else
-        return esc(expr)
+
+function Base.filter(f, r::RecordDatabase)
+
+    for i in keys(r)
+
+       judgements(r[i])[:Study] = filter(f, Study(r[i]))
+
+        for j in eachindex(Study(r[i]))
+
+            filtered_model = filter(f, Model(Study(r[i])[j]))
+           judgements(judgements(r[i])[:Study][j])[:Model] = length(filtered_model) > 0 ? filtered_model : Model(Study(r[i])[j])
+
+        end
+        
     end
+
+    return r
 end
 
-f = @remove_model x -> get(Model(Study(x)), :Standardized)[1] == true
+filter(z -> rating(get(z, :N)) == 100, db)
+Study(db[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")])
 
-for i in eachindex(s)
-    Model(s[i]) = filter(f, Model(s[i]))
-end
+## Yaaay, this actually worked. Clean up now and try with edge cases and TAxons. 
 
-
-
-## so:
-## 1) Extract the values without changing the function. This would require to 
-## Define methods for Model and Study that can deal with vectors as input. Not quite sure
-## How that would look. 
-## Advantage: I could look at the resulting judgementLevel and use this as 
-## function for updating the record Database at the correct position.
-
-## How did I do this with rating? 
-## I went through the vector outside of filter, and then just provided
-## The input the function needed. This actually is similar to the second approach:
-
-
-## 2) Use a macro to transform the function so it extracts values at Model[i], Study[i] ...
-## 
-
-
-## Problem: Within each study we also need to get a vector of models.
-## How to allocate the correct models to the correct study? 
+# filter(z -> rating(get(z, :Lang)) == "en", test_record)
+# filter(z -> rating(get(z, :N)) == 100, Study(test_record))
+# filter(z -> rating(get(z, :Standardized)) == true, Model(Study(test_record)[1]))
 
 
 
 
-
-
-
-test_level = judgement_level(f(test_record))
-
-typeof(test_level)
-
-## Use this as function, maybe as macro?
-
-## Name update_ModelJudgement if possible
-j = 1
-
-filtered = filter(f)
-
-ModelJudgement(r::Record, j, filtered)
-    Model(Study(r)[j]) = filtered
-end
-
-
-Model(Study(test_record)[1])[1] = N(100)
-
-
-
-f(test_record) = Standardized(false)
-
-## Take this and us it to automatically extract the vector where it should be saved.
-## Maybe use a macro ?
-
-
-## About indices: I can just go through with a loop and return vector. 
-
-
-# Currently filter filters a vector of Studies or a Vector of Models and returns it 
-# inside the record or study judgements field. 
-end
 

--- a/test/extractors.jl
+++ b/test/extractors.jl
@@ -1,7 +1,91 @@
 @testset "factor_variance" begin
-    measurement = Measurement(n_variables = 2, loadings = [1, 0.4], factor_variance = 1.0)
-    standalone_factor = StandaloneFactor(n_variables = 2, loadings = [0.1, 0.2], factor_variance = 0.5)
+    measurement = Measurement(n_variables=2, loadings=[1, 0.4], factor_variance=1.0)
+    standalone_factor = StandaloneFactor(n_variables=2, loadings=[0.1, 0.2], factor_variance=0.5)
 
     @test rating(factor_variance(measurement)) == 1.0
     @test rating(factor_variance(standalone_factor)) == 0.5
+end
+
+@testset "extract studies" begin
+
+    test_record_1 = Record(
+        rater="NH",
+        id="2a129694-550c-4396-be6f-00507b1dc7bb",
+        Lang("en"),
+        Study(
+            N(100),
+            Model(
+                Standardized(true)
+            )
+        )
+    )
+
+    @test typeof(Study(test_record_1)) == Vector{Union{JudgementLevel,AbstractJudgement}}
+    @test length(Study(test_record_1)) == 1
+
+    test_record_2 = Record(
+        rater="NH",
+        id="2a129694-550c-4396-be6f-00507b1dc7bb",
+        Lang("en"),
+        Study(
+            N(100),
+            Model(
+                Standardized(true)
+            )
+        ),
+        Study(
+            N(200),
+            Model(
+                Standardized(false)
+            )
+        )
+    )
+
+    @test typeof(Study(test_record_2)) == Vector{Union{JudgementLevel,AbstractJudgement}}
+    @test length(Study(test_record_2)) == 2
+
+
+    test_record_0 = Record(
+        rater="NH",
+        id="2a129694-550c-4396-be6f-00507b1dc7bb",
+        Lang("en")
+    )
+
+    @test typeof(Study(test_record_0)) == Vector{Union{JudgementLevel,AbstractJudgement}}
+    @test length(Study(test_record_0)) == 0
+end
+
+
+@testset "extract models" begin
+    test_study_1 = Study(
+        N(100),
+        Model(
+            Standardized(true)
+        )
+    )
+
+    @test typeof(Model(test_study_1)) == Vector{Union{JudgementLevel,AbstractJudgement}}
+    @test length(Model(test_study_1)) == 1
+
+
+    test_study_2 = Study(
+        N(100),
+        Model(
+            Standardized(true)
+        ),
+        Model(
+            Standardized(false)
+        )
+    )
+
+
+    @test typeof(Model(test_study_2)) == Vector{Union{JudgementLevel,AbstractJudgement}}
+    @test length(Model(test_study_2)) == 2
+
+    test_study_0 = Study(
+        N(100)
+    )
+
+    @test typeof(Model(test_study_0)) == Vector{Union{JudgementLevel,AbstractJudgement}}
+    @test length(Model(test_study_0)) == 0
 end

--- a/test/extractors.jl
+++ b/test/extractors.jl
@@ -19,10 +19,10 @@ end
             )
         )
     )
-
     @test typeof(Study(test_record_1)) == Vector{Union{Study,AbstractJudgement}}
     @test length(Study(test_record_1)) == 1
     @test rating(Study(judgements(test_record_1))[1], :N) == 100
+
 
     test_record_2 = Record(
         rater="NH",
@@ -41,7 +41,6 @@ end
             )
         )
     )
-
     @test typeof(Study(test_record_2)) == Vector{Union{Study,AbstractJudgement}}
     @test length(Study(test_record_2)) == 2
 
@@ -51,7 +50,6 @@ end
         id="2a129694-550c-4396-be6f-00507b1dc7bb",
         Lang("en")
     )
-
     @test typeof(Study(test_record_0)) == Vector{Union{Study,AbstractJudgement}}
     @test length(Study(test_record_0)) == 0
     @test length(Study(judgements(test_record_0))) == 0
@@ -66,9 +64,9 @@ end
             Standardized(true)
         )
     )
-
     @test typeof(Model(test_study_1)) == Vector{Union{Model,AbstractJudgement}}
     @test length(Model(test_study_1)) == 1
+
 
     test_study_2 = Study(
         N(100),
@@ -79,26 +77,25 @@ end
             Standardized(false)
         )
     )
-
-
     @test typeof(Model(test_study_2)) == Vector{Union{Model,AbstractJudgement}}
     @test length(Model(test_study_2)) == 2
+
 
     test_study_0 = Study(
         N(100)
     )
-
     @test typeof(Model(test_study_0)) == Vector{Union{Model,AbstractJudgement}}
     @test length(Model(test_study_0)) == 0
 end
 
 @testset "get for JudgementLevel" begin
     @test get(Study(N(100)), :N)[1] == N(100)
-    @test get(Study(N(100)), :Z) == Vector{Union{JudgementLevel, AbstractJudgement}}[]
+    @test get(Study(N(100)), :Z) == Vector{Union{JudgementLevel,AbstractJudgement}}[]
 end
 
 
 @testset "extract Taxons" begin
+
     test_model = Model(Standardized(true),
         LatentPathmodel(
             Structural(structural_model=missing),
@@ -121,7 +118,6 @@ end
             )
         )
     )
-
     @test typeof(Taxon(test_model)[1]) == LatentPathmodel
     @test length(Taxon(test_model)) == 2
 end

--- a/test/extractors.jl
+++ b/test/extractors.jl
@@ -96,3 +96,152 @@ end
     @test get(Study(N(100)), :N)[1] == N(100)
     @test get(Study(N(100)), :Z) == []
 end
+
+
+@testset "extract Taxons" begin
+    test_model = Model(Standardized(true),
+        LatentPathmodel(
+            Structural(structural_model=missing),
+            Dict(
+                :IP => Measurement(n_variables=3, factor_variance=missing, loadings=missing, quest_scale=7),
+                :IN => Measurement(n_variables=4, factor_variance=missing, loadings=missing, quest_scale=6),
+                :DN => Measurement(n_variables=3, factor_variance=missing, loadings=missing, quest_scale=7),
+                :BC => Measurement(n_variables=3, factor_variance=missing, loadings=missing, quest_scale=5),
+                :IB => Measurement(n_variables=5, factor_variance=missing, loadings=missing, quest_scale=5)
+            )
+        ),
+        LatentPathmodel(
+            Structural(structural_model=missing),
+            Dict(
+                :IP => Measurement(n_variables=3, factor_variance=missing, loadings=missing, quest_scale=7),
+                :IN => Measurement(n_variables=4, factor_variance=missing, loadings=missing, quest_scale=6),
+                :DN => Measurement(n_variables=3, factor_variance=missing, loadings=missing, quest_scale=7),
+                :BC => Measurement(n_variables=3, factor_variance=missing, loadings=missing, quest_scale=5),
+                :IB => Measurement(n_variables=5, factor_variance=missing, loadings=missing, quest_scale=5)
+            )
+        )
+    )
+
+    @test typeof(Taxon(test_model)[1]) == LatentPathmodel
+    @test length(Taxon(test_model)) == 2
+end
+
+@testset "extract measurement_model" begin
+    
+
+    test_record = Record(
+        rater="VK",
+        id="2a129694-550c-4396-be6f-00507b1dc7ba",
+        Lang("en"),
+        Study(
+            N(100),
+            Model(Standardized(true), 
+            LatentPathmodel(
+                Structural(structural_model = missing ),
+                Dict(
+                    :IP => Measurement(n_variables = 3, factor_variance = missing, loadings = missing, quest_scale = 7),
+                    :IN => Measurement(n_variables = 4, factor_variance = missing, loadings = missing, quest_scale = 6),
+                    :DN => Measurement(n_variables = 3, factor_variance = missing, loadings = missing, quest_scale = 7),
+                    :BC => Measurement(n_variables = 3, factor_variance = missing, loadings = missing, quest_scale = 5),
+                    :IB => Measurement(n_variables = 5, factor_variance = missing, loadings = missing, quest_scale = 5)
+                )
+            )),
+            Model(Standardized(false))
+        ), 
+        Study(N(120))
+    )
+
+
+
+f = x -> get(Model(Study(x)), :Standardized)[1] == true
+
+## Define for vectors
+s = Study(test_record)
+
+function Model(s::Vector{Union{JudgementLevel, AbstractJudgement}})
+res_vec = []
+for i in eachindex(s)
+    push!(res_vec, Model(s[i]))
+end
+
+return res_vec
+end
+
+Model(s)
+
+## Or
+
+macro remove_model(expr)
+    if isa(expr, Expr) && expr.head == :call && expr.args[1] == :Model
+        return esc(expr.args[2])
+    else
+        return esc(expr)
+    end
+end
+
+f = @remove_model x -> get(Model(Study(x)), :Standardized)[1] == true
+
+for i in eachindex(s)
+    Model(s[i]) = filter(f, Model(s[i]))
+end
+
+
+
+## so:
+## 1) Extract the values without changing the function. This would require to 
+## Define methods for Model and Study that can deal with vectors as input. Not quite sure
+## How that would look. 
+## Advantage: I could look at the resulting judgementLevel and use this as 
+## function for updating the record Database at the correct position.
+
+## How did I do this with rating? 
+## I went through the vector outside of filter, and then just provided
+## The input the function needed. This actually is similar to the second approach:
+
+
+## 2) Use a macro to transform the function so it extracts values at Model[i], Study[i] ...
+## 
+
+
+## Problem: Within each study we also need to get a vector of models.
+## How to allocate the correct models to the correct study? 
+
+
+
+
+
+
+
+test_level = judgement_level(f(test_record))
+
+typeof(test_level)
+
+## Use this as function, maybe as macro?
+
+## Name update_ModelJudgement if possible
+j = 1
+
+filtered = filter(f)
+
+ModelJudgement(r::Record, j, filtered)
+    Model(Study(r)[j]) = filtered
+end
+
+
+Model(Study(test_record)[1])[1] = N(100)
+
+
+
+f(test_record) = Standardized(false)
+
+## Take this and us it to automatically extract the vector where it should be saved.
+## Maybe use a macro ?
+
+
+## About indices: I can just go through with a loop and return vector. 
+
+
+# Currently filter filters a vector of Studies or a Vector of Models and returns it 
+# inside the record or study judgements field. 
+end
+

--- a/test/extractors.jl
+++ b/test/extractors.jl
@@ -22,6 +22,7 @@ end
 
     @test typeof(Study(test_record_1)) == Vector{Union{JudgementLevel,AbstractJudgement}}
     @test length(Study(test_record_1)) == 1
+    @test rating(Study(judgements(test_record_1))[1], :N) == 100
 
     test_record_2 = Record(
         rater="NH",
@@ -53,6 +54,8 @@ end
 
     @test typeof(Study(test_record_0)) == Vector{Union{JudgementLevel,AbstractJudgement}}
     @test length(Study(test_record_0)) == 0
+    @test length(Study(judgements(test_record_0))) == 0
+
 end
 
 
@@ -66,7 +69,6 @@ end
 
     @test typeof(Model(test_study_1)) == Vector{Union{JudgementLevel,AbstractJudgement}}
     @test length(Model(test_study_1)) == 1
-
 
     test_study_2 = Study(
         N(100),

--- a/test/filter.jl
+++ b/test/filter.jl
@@ -15,7 +15,8 @@ end
         Lang("en"),
         Study(
             N(100),
-            Model(Standardized(true)),
+            Model(Standardized(true)
+                  ),
             Model(Standardized(false))
         ),
         Study(

--- a/test/filter.jl
+++ b/test/filter.jl
@@ -5,6 +5,51 @@
 end
 
 
+
+@testset "filter database on Record level" begin
+    test_db = RecordDatabase()
+
+    test_db += Record(
+        rater="VK",
+        id="2a129694-550c-4396-be6f-00507b1dc7ba",
+        Lang("en"),
+        Study(
+            N(100),
+            Model(Standardized(true)),
+            Model(Standardized(false))
+        ),
+        Study(
+            N(200),
+            Model(Standardized(false)),
+            Model(Standardized(false))
+        )
+    )
+
+    test_db += Record(
+        rater="VK",
+        id="7548949d-b2f5-436f-8577-4237fb51d5a7",
+        Lang("de"),
+        Study(
+            N(100),
+            Model(Standardized(true)),
+            Model(Standardized(false))
+        )
+    )
+
+    test_db += Record(
+        rater="VK",
+        id="7548949d-b2f5-436f-8577-4237fb51d5a8",
+        Lang("de")
+    )
+
+    filtered_record = filter(x -> rating(x, :Lang) == "en", test_db, Record())
+
+
+    ## Check if the correct records were filtered
+    @test length(filtered_record) == 1
+    @test rating(filtered_record[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")], :Lang) == "en"
+end
+
 @testset "filter database on Study level" begin
     test_db = RecordDatabase()
 

--- a/test/filter.jl
+++ b/test/filter.jl
@@ -8,7 +8,7 @@ end
     test_db = RecordDatabase()
 
     test_db += Record(
-        rater="VK",
+        rater="NH",
         id="2a129694-550c-4396-be6f-00507b1dc7ba",
         Lang("en"),
         Study(
@@ -25,7 +25,7 @@ end
     )
 
     test_db += Record(
-        rater="VK",
+        rater="NH",
         id="7548949d-b2f5-436f-8577-4237fb51d5a7",
         Lang("de"),
         Study(
@@ -36,24 +36,35 @@ end
     )
 
     test_db += Record(
-        rater="VK",
+        rater="NH",
         id="7548949d-b2f5-436f-8577-4237fb51d5a8",
         Lang("de")
     )
 
-    filtered_record = filter(x -> rating(x, :Lang) == "en", test_db, Record())
-
+    filtered_db_en = filter(x -> rating(x, :Lang) == "en", test_db, "Record")
+    filtered_db_de = filter(x -> rating(x, :Lang) == "de", test_db, "Record")
 
     ## Check if the correct records were filtered
-    @test length(filtered_record) == 1
-    @test rating(filtered_record[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")], :Lang) == "en"
+    @test length(filtered_db_en) == 1
+    @test rating(filtered_db_en[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")], :Lang) == "en"
+
+    @test length(filtered_db_de) == 2
+    @test rating(filtered_db_de[Base.UUID("7548949d-b2f5-436f-8577-4237fb51d5a7")], :Lang) == "de"
+
+
+    ## Edge case: No record fits the filter function
+    filtered_db_fr = filter(x -> rating(x, :Lang) == "fr", test_db, "Record")
+
+    @test length(filtered_db_fr) == 0
+    @test typeof(filtered_db_fr) == RecordDatabase{Base.UUID,Record}
+
 end
 
 @testset "filter database on Study level" begin
     test_db = RecordDatabase()
 
     test_db += Record(
-        rater="VK",
+        rater="NH",
         id="2a129694-550c-4396-be6f-00507b1dc7ba",
         Lang("en"),
         Study(
@@ -69,7 +80,7 @@ end
     )
 
     test_db += Record(
-        rater="VK",
+        rater="NH",
         id="7548949d-b2f5-436f-8577-4237fb51d5a7",
         Lang("de"),
         Study(
@@ -80,43 +91,66 @@ end
     )
 
     test_db += Record(
-        rater="VK",
+        rater="NH",
         id="7548949d-b2f5-436f-8577-4237fb51d5a8",
         Lang("de")
     )
 
-    filtered_study = filter(x -> rating(x, :N) == 200, test_db, Study())
 
+    ########################
+    ## filtered_study_fit ##
+    ########################
+    filtered_study_fit = filter(x -> rating(x, :N) == 200, test_db, "Study")
     ## Check if the correct studies were filtered
-    @test length(Study(filtered_study[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")])) == 1
-    @test rating(Study(filtered_study[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")])[1], :N) == 200
-
+    @test length(Study(filtered_study_fit[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")])) == 1
+    @test rating(Study(filtered_study_fit[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")])[1], :N) == 200
     ## Dealing with cases where no case fits the filter function or where there is no Model in a Study:
-    @test length(Study(filtered_study[Base.UUID("7548949d-b2f5-436f-8577-4237fb51d5a7")])) == 0
-    @test length(Study(filtered_study[Base.UUID("7548949d-b2f5-436f-8577-4237fb51d5a8")])) == 0
+    @test :Study ∉ keys(judgements(filtered_study_fit[Base.UUID("7548949d-b2f5-436f-8577-4237fb51d5a7")]))
+    @test :Study ∉ keys(judgements(filtered_study_fit[Base.UUID("7548949d-b2f5-436f-8577-4237fb51d5a8")]))
+
+    ##########################
+    ## filtered_study_nofit ##
+    ##########################
+    filtered_study_nofit = filter(x -> rating(x, :N) == 2000, test_db, "Study")
+    # There shouldn't be any study field left     
+    for i in keys(filtered_study_nofit)
+        @test :Study ∉ keys(judgements(filtered_study_nofit[i]))
+    end
+
+    ############################
+    ## filtered_study_nofield ##
+    ############################
+    filtered_study_nofield = filter(x -> rating(x, :NoField) == 2000, test_db, "Study")
+
+    # There shouldn't be any study field left     
+    for i in keys(filtered_study_nofield)
+        @test :Study ∉ keys(judgements(filtered_study_nofield[i]))
+    end
+
 end
 
 @testset "filter database on Model level" begin
     test_db = RecordDatabase()
 
     test_db += Record(
-        rater="VK",
+        rater="NH",
         id="2a129694-550c-4396-be6f-00507b1dc7ba",
         Lang("en"),
         Study(
             N(100),
-            Model(Standardized(true)),
+            Model(Standardized(true), Quest("What are some best practices for managing memory usage in large-scale data processing applications?")),
             Model(Standardized(false))
         ),
         Study(
             N(200),
             Model(Standardized(false)),
-            Model(Standardized(false))
+            Model(Standardized(false)),
+            Model(Quest("What is the role of artificial intelligence in shaping our understanding of consciousness and self-awareness?"))
         )
     )
 
     test_db += Record(
-        rater="VK",
+        rater="NH",
         id="7548949d-b2f5-436f-8577-4237fb51d5a7",
         Lang("de"),
         Study(
@@ -127,7 +161,7 @@ end
     )
 
     test_db += Record(
-        rater="VK",
+        rater="NH",
         id="7548949d-b2f5-436f-8577-4237fb51d5a8",
         Lang("de"),
         Study(
@@ -135,71 +169,33 @@ end
         )
     )
 
-    filtered_model = filter(x -> rating(x, :Standardized) == true, test_db, Model())
+    filtered_db_fit = filter(x -> rating(x, :Standardized) == true, test_db, "Model")
+
 
     ## Check if the correct studies were filtered
-    @test rating(Model(Study(filtered_model[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")])[1])[1], :Standardized) == true
-    @test length(Model(Study(filtered_model[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")])[1])) == 1
-    @test length(Model(Study(filtered_model[Base.UUID("7548949d-b2f5-436f-8577-4237fb51d5a7")])[1])) == 1
-    @test rating(Model(Study(filtered_model[Base.UUID("7548949d-b2f5-436f-8577-4237fb51d5a7")])[1])[1], :Standardized) == true
+    @test rating(Model(Study(filtered_db_fit[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")])[1])[1], :Standardized) == true
+    @test length(Model(Study(filtered_db_fit[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")])[1])) == 1
+    @test length(Model(Study(filtered_db_fit[Base.UUID("7548949d-b2f5-436f-8577-4237fb51d5a7")])[1])) == 1
+    @test rating(Model(Study(filtered_db_fit[Base.UUID("7548949d-b2f5-436f-8577-4237fb51d5a7")])[1])[1], :Standardized) == true
 
     ## Dealing with cases where no case fits the filter function or where there is no Model in a Study:
-    @test length(Model(Study(filtered_model[Base.UUID("7548949d-b2f5-436f-8577-4237fb51d5a8")])[1])) == 0
-    @test length(Model(Study(filtered_model[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")])[2])) == 0
+    @test :Model ∉ keys(judgements(Study(filtered_db_fit[Base.UUID("7548949d-b2f5-436f-8577-4237fb51d5a8")])[1]))
+    @test :Model ∉ keys(judgements(Study(filtered_db_fit[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")])[2]))
 
-end
 
-@testset "filter database on Taxon level" begin
-    test_db = RecordDatabase()
+    ##########################
+    ## filtered_model_nofit ##
+    ##########################
+    filtered_db_nofit = filter(x -> certainty(x, :Standardized) < 1, test_db, "Model")
 
-    test_db += Record(
-        rater="VK",
-        id="2a129694-550c-4396-be6f-00507b1dc7ba",
-        Lang("en"),
-        Study(
-            N(100),
-            Model(Standardized(true)),
-            Model(Standardized(false))
-        ),
-        Study(
-            N(200),
-            Model(Standardized(false)),
-            Model(Standardized(false))
-        )
-    )
 
-    test_db += Record(
-        rater="VK",
-        id="7548949d-b2f5-436f-8577-4237fb51d5a7",
-        Lang("de"),
-        Study(
-            N(100),
-            Model(Standardized(true)),
-            Model(Standardized(false))
-        )
-    )
-
-    test_db += Record(
-        rater="VK",
-        id="7548949d-b2f5-436f-8577-4237fb51d5a8",
-        Lang("de"),
-        Study(
-            N(100)
-        )
-    )
-
-    filtered_model = filter(x -> rating(x, :Standardized) == true, test_db, Model())
-
-    ## Check if the correct studies were filtered
-    @test rating(Model(Study(filtered_model[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")])[1])[1], :Standardized) == true
-    @test length(Model(Study(filtered_model[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")])[1])) == 1
-    @test length(Model(Study(filtered_model[Base.UUID("7548949d-b2f5-436f-8577-4237fb51d5a7")])[1])) == 1
-    @test rating(Model(Study(filtered_model[Base.UUID("7548949d-b2f5-436f-8577-4237fb51d5a7")])[1])[1], :Standardized) == true
-
-    ## Dealing with cases where no case fits the filter function or where there is no Model in a Study:
-    @test length(Model(Study(filtered_model[Base.UUID("7548949d-b2f5-436f-8577-4237fb51d5a8")])[1])) == 0
-    @test length(Model(Study(filtered_model[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")])[2])) == 0
-
+    # There shouldn't be any Model field left     
+    for i in keys(filtered_db_nofit)
+        record_studies = Study(filtered_db_nofit[i])
+        for j in eachindex(record_studies)
+            @test :Model ∉ keys(judgements(record_studies[j]))
+        end
+    end
 end
 
 
@@ -207,8 +203,8 @@ end
 
     test_db = RecordDatabase()
 
-    test_record = Record(
-        rater="VK",
+    test_db += Record(
+        rater="NH",
         id="2a129694-550c-4396-be6f-00507b1dc7ba",
         Lang("en"),
         Study(
@@ -237,32 +233,65 @@ end
         )
     )
 
-test_db += test_record
+    test_db += Record(
+        rater="NH",
+        id="2a129694-550c-4396-be6f-00507b1dc7bb",
+        Lang("en"),
+        Study(
+            N(100),
+            Model(Standardized(true),
+                LatentPathmodel(
+                    Structural(structural_model=missing),
+                    Dict(
+                        :IP => Measurement(n_variables=3, factor_variance=missing, loadings=missing, quest_scale=7),
+                        :IN => Measurement(n_variables=4, factor_variance=missing, loadings=missing, quest_scale=6),
+                        :DN => Measurement(n_variables=3, factor_variance=missing, loadings=missing, quest_scale=7),
+                        :BC => Measurement(n_variables=3, factor_variance=missing, loadings=missing, quest_scale=5),
+                        :IB => Measurement(n_variables=5, factor_variance=missing, loadings=missing, quest_scale=5)
+                    )
+                )
+            ),
+            Model(Standardized(true),
+                NoTaxon()
+            )
+        ),
+        Study(
+            N(200),
+            Model(Standardized(false)),
+            Model(Standardized(false),
+                NoTaxon(),
+                LatentPathmodel(
+                    Structural(structural_model=missing),
+                    Dict(
+                        :IP => Measurement(n_variables=3, factor_variance=missing, loadings=missing, quest_scale=7),
+                        :IN => Measurement(n_variables=4, factor_variance=missing, loadings=missing, quest_scale=6),
+                        :DN => Measurement(n_variables=3, factor_variance=missing, loadings=missing, quest_scale=7),
+                        :BC => Measurement(n_variables=3, factor_variance=missing, loadings=missing, quest_scale=5),
+                        :IB => Measurement(n_variables=5, factor_variance=missing, loadings=missing, quest_scale=5)
+                    )
+                ))
+        )
+    )
 
-res_db = filter(f, test_db, "Taxon")
+    filtered_db_fit = filter(x -> typeof(x) == LatentPathmodel, test_db, "Taxon")
 
+    @test typeof(Taxon(Model(Study(filtered_db_fit[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")])[1])[1])[1]) == LatentPathmodel
+    @test :Taxon ∉ keys(judgements(Model(Study(filtered_db_fit[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")])[1])[2]))
+    @test typeof(Taxon(Model(Study(filtered_db_fit[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7bb")])[1])[1])[1]) == LatentPathmodel
+    @test :Taxon ∉ keys(judgements(Model(Study(filtered_db_fit[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7bb")])[2])[1]))
+    @test length(Taxon(Model(Study(filtered_db_fit[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7bb")])[2])[2])) == 1
+    @test typeof(Taxon(Model(Study(filtered_db_fit[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7bb")])[2])[2])[1]) == LatentPathmodel
 
-@test length(Model(Study(res_db[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")])[1])) == 2
-@test length(Model(Study(res_db[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")])[2])) == 2
-@test typeof(Taxon(Model(Study(res_db[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")])[1])[1])[1]) == LatentPathmodel
-@test :Taxon ∉ keys(judgements(Model(Study(res_db[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")])[1])[2]))
+    filtered_db_nofit = filter(x -> typeof(x) == NoTaxonYet, test_db, "Taxon")
 
-
-## Delete! Empty fields from other JudgementLevels as well. 
-
-## Some notes:
-## How to deal with NA?
-
-####################
-## Test procedure ##
-####################
-
-# for current_study in eachindex(Study(test_record))
-#     for current_model in eachindex(Model(Study(test_record)[current_study]))
-#         taxons = Taxon(Model(Study(test_record)[current_study])[current_model])
-#             judgements(Model(Study(test_record)[current_study])[current_model])[:Taxon] = filter(f, taxons)
-#     end
-# end
-
-
+    # There shouldn't be any Taxon field left     
+    for i in keys(filtered_db_nofit)
+        record_studies = Study(filtered_db_nofit[i])
+        for j in record_studies
+            study_models = Model(j)
+            for k in study_models
+                @test :Taxon ∉ keys(judgements(k))
+            end
+        end
+    end
 end

--- a/test/filter.jl
+++ b/test/filter.jl
@@ -4,8 +4,6 @@
     @test length(filter(x -> rating(x, :Empirical) == false, Study(Empirical(true)))) == 0
 end
 
-
-
 @testset "filter database on Record level" begin
     test_db = RecordDatabase()
 
@@ -16,7 +14,7 @@ end
         Study(
             N(100),
             Model(Standardized(true)
-                  ),
+            ),
             Model(Standardized(false))
         ),
         Study(
@@ -98,7 +96,6 @@ end
     @test length(Study(filtered_study[Base.UUID("7548949d-b2f5-436f-8577-4237fb51d5a8")])) == 0
 end
 
-
 @testset "filter database on Model level" begin
     test_db = RecordDatabase()
 
@@ -149,5 +146,123 @@ end
     ## Dealing with cases where no case fits the filter function or where there is no Model in a Study:
     @test length(Model(Study(filtered_model[Base.UUID("7548949d-b2f5-436f-8577-4237fb51d5a8")])[1])) == 0
     @test length(Model(Study(filtered_model[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")])[2])) == 0
+
+end
+
+@testset "filter database on Taxon level" begin
+    test_db = RecordDatabase()
+
+    test_db += Record(
+        rater="VK",
+        id="2a129694-550c-4396-be6f-00507b1dc7ba",
+        Lang("en"),
+        Study(
+            N(100),
+            Model(Standardized(true)),
+            Model(Standardized(false))
+        ),
+        Study(
+            N(200),
+            Model(Standardized(false)),
+            Model(Standardized(false))
+        )
+    )
+
+    test_db += Record(
+        rater="VK",
+        id="7548949d-b2f5-436f-8577-4237fb51d5a7",
+        Lang("de"),
+        Study(
+            N(100),
+            Model(Standardized(true)),
+            Model(Standardized(false))
+        )
+    )
+
+    test_db += Record(
+        rater="VK",
+        id="7548949d-b2f5-436f-8577-4237fb51d5a8",
+        Lang("de"),
+        Study(
+            N(100)
+        )
+    )
+
+    filtered_model = filter(x -> rating(x, :Standardized) == true, test_db, Model())
+
+    ## Check if the correct studies were filtered
+    @test rating(Model(Study(filtered_model[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")])[1])[1], :Standardized) == true
+    @test length(Model(Study(filtered_model[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")])[1])) == 1
+    @test length(Model(Study(filtered_model[Base.UUID("7548949d-b2f5-436f-8577-4237fb51d5a7")])[1])) == 1
+    @test rating(Model(Study(filtered_model[Base.UUID("7548949d-b2f5-436f-8577-4237fb51d5a7")])[1])[1], :Standardized) == true
+
+    ## Dealing with cases where no case fits the filter function or where there is no Model in a Study:
+    @test length(Model(Study(filtered_model[Base.UUID("7548949d-b2f5-436f-8577-4237fb51d5a8")])[1])) == 0
+    @test length(Model(Study(filtered_model[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")])[2])) == 0
+
+end
+
+
+@testset "Test Filter on Taxon level" begin
+
+    test_db = RecordDatabase()
+
+    test_record = Record(
+        rater="VK",
+        id="2a129694-550c-4396-be6f-00507b1dc7ba",
+        Lang("en"),
+        Study(
+            N(100),
+            Model(Standardized(true),
+                LatentPathmodel(
+                    Structural(structural_model=missing),
+                    Dict(
+                        :IP => Measurement(n_variables=3, factor_variance=missing, loadings=missing, quest_scale=7),
+                        :IN => Measurement(n_variables=4, factor_variance=missing, loadings=missing, quest_scale=6),
+                        :DN => Measurement(n_variables=3, factor_variance=missing, loadings=missing, quest_scale=7),
+                        :BC => Measurement(n_variables=3, factor_variance=missing, loadings=missing, quest_scale=5),
+                        :IB => Measurement(n_variables=5, factor_variance=missing, loadings=missing, quest_scale=5)
+                    )
+                )
+            ),
+            Model(Standardized(true),
+                NoTaxon()
+            )
+        ),
+        Study(
+            N(200),
+            Model(Standardized(false),
+            ),
+            Model(Standardized(false))
+        )
+    )
+
+test_db += test_record
+
+res_db = filter(f, test_db, "Taxon")
+
+
+@test length(Model(Study(res_db[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")])[1])) == 2
+@test length(Model(Study(res_db[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")])[2])) == 2
+@test typeof(Taxon(Model(Study(res_db[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")])[1])[1])[1]) == LatentPathmodel
+@test :Taxon ∉ keys(judgements(Model(Study(res_db[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")])[1])[2]))
+
+
+## Delete! Empty fields from other JudgementLevels as well. 
+
+## Some notes:
+## How to deal with NA?
+
+####################
+## Test procedure ##
+####################
+
+# for current_study in eachindex(Study(test_record))
+#     for current_model in eachindex(Model(Study(test_record)[current_study]))
+#         taxons = Taxon(Model(Study(test_record)[current_study])[current_model])
+#             judgements(Model(Study(test_record)[current_study])[current_model])[:Taxon] = filter(f, taxons)
+#     end
+# end
+
 
 end

--- a/test/filter.jl
+++ b/test/filter.jl
@@ -4,6 +4,9 @@
     @test length(filter(x -> rating(x, :Empirical) == false, Study(Empirical(true)))) == 0
 end
 
+
+
+
 @testset "filter database on Record level" begin
     test_db = RecordDatabase()
 
@@ -23,7 +26,6 @@ end
             Model(Standardized(false))
         )
     )
-
     test_db += Record(
         rater="NH",
         id="7548949d-b2f5-436f-8577-4237fb51d5a7",
@@ -34,7 +36,6 @@ end
             Model(Standardized(false))
         )
     )
-
     test_db += Record(
         rater="NH",
         id="7548949d-b2f5-436f-8577-4237fb51d5a8",
@@ -47,18 +48,16 @@ end
     ## Check if the correct records were filtered
     @test length(filtered_db_en) == 1
     @test rating(filtered_db_en[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")], :Lang) == "en"
-
     @test length(filtered_db_de) == 2
     @test rating(filtered_db_de[Base.UUID("7548949d-b2f5-436f-8577-4237fb51d5a7")], :Lang) == "de"
-
-
     ## Edge case: No record fits the filter function
     filtered_db_fr = filter(x -> rating(x, :Lang) == "fr", test_db, "Record")
-
     @test length(filtered_db_fr) == 0
     @test typeof(filtered_db_fr) == RecordDatabase{Base.UUID,Record}
-
 end
+
+
+
 
 @testset "filter database on Study level" begin
     test_db = RecordDatabase()
@@ -96,7 +95,6 @@ end
         Lang("de")
     )
 
-
     ########################
     ## filtered_study_fit ##
     ########################
@@ -121,17 +119,17 @@ end
     ## filtered_study_nofield ##
     ############################
     filtered_study_nofield = filter(x -> rating(x, :NoField) == 2000, test_db, "Study")
-
     # There shouldn't be any study field left     
     for i in keys(filtered_study_nofield)
         @test :Study ∉ keys(judgements(filtered_study_nofield[i]))
     end
-
 end
+
+
+
 
 @testset "filter database on Model level" begin
     test_db = RecordDatabase()
-
     test_db += Record(
         rater="NH",
         id="2a129694-550c-4396-be6f-00507b1dc7ba",
@@ -148,7 +146,6 @@ end
             Model(Quest("What is the role of artificial intelligence in shaping our understanding of consciousness and self-awareness?"))
         )
     )
-
     test_db += Record(
         rater="NH",
         id="7548949d-b2f5-436f-8577-4237fb51d5a7",
@@ -159,7 +156,6 @@ end
             Model(Standardized(false))
         )
     )
-
     test_db += Record(
         rater="NH",
         id="7548949d-b2f5-436f-8577-4237fb51d5a8",
@@ -171,13 +167,11 @@ end
 
     filtered_db_fit = filter(x -> rating(x, :Standardized) == true, test_db, "Model")
 
-
     ## Check if the correct studies were filtered
     @test rating(Model(Study(filtered_db_fit[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")])[1])[1], :Standardized) == true
     @test length(Model(Study(filtered_db_fit[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")])[1])) == 1
     @test length(Model(Study(filtered_db_fit[Base.UUID("7548949d-b2f5-436f-8577-4237fb51d5a7")])[1])) == 1
     @test rating(Model(Study(filtered_db_fit[Base.UUID("7548949d-b2f5-436f-8577-4237fb51d5a7")])[1])[1], :Standardized) == true
-
     ## Dealing with cases where no case fits the filter function or where there is no Model in a Study:
     @test :Model ∉ keys(judgements(Study(filtered_db_fit[Base.UUID("7548949d-b2f5-436f-8577-4237fb51d5a8")])[1]))
     @test :Model ∉ keys(judgements(Study(filtered_db_fit[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")])[2]))
@@ -187,8 +181,6 @@ end
     ## filtered_model_nofit ##
     ##########################
     filtered_db_nofit = filter(x -> certainty(x, :Standardized) < 1, test_db, "Model")
-
-
     # There shouldn't be any Model field left     
     for i in keys(filtered_db_nofit)
         record_studies = Study(filtered_db_nofit[i])
@@ -199,10 +191,10 @@ end
 end
 
 
+
+
 @testset "Test Filter on Taxon level" begin
-
     test_db = RecordDatabase()
-
     test_db += Record(
         rater="NH",
         id="2a129694-550c-4396-be6f-00507b1dc7ba",
@@ -232,7 +224,6 @@ end
             Model(Standardized(false))
         )
     )
-
     test_db += Record(
         rater="NH",
         id="2a129694-550c-4396-be6f-00507b1dc7bb",
@@ -282,8 +273,10 @@ end
     @test length(Taxon(Model(Study(filtered_db_fit[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7bb")])[2])[2])) == 1
     @test typeof(Taxon(Model(Study(filtered_db_fit[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7bb")])[2])[2])[1]) == LatentPathmodel
 
+    ##########################
+    ## filtered_taxon_nofit ##
+    ##########################
     filtered_db_nofit = filter(x -> typeof(x) == NoTaxonYet, test_db, "Taxon")
-
     # There shouldn't be any Taxon field left     
     for i in keys(filtered_db_nofit)
         record_studies = Study(filtered_db_nofit[i])

--- a/test/filter.jl
+++ b/test/filter.jl
@@ -1,0 +1,107 @@
+@testset "filter on judgementlevels" begin
+    @test length(filter(x -> rating(x, :Standardized) == true, [Model(Standardized(true)), Model(Standardized(true)), Model(Standardized(false))])) == 2
+    @test rating(filter(x -> rating(x, :Empirical) == true, Study(Empirical(true)))[1], :Empirical) == true
+    @test length(filter(x -> rating(x, :Empirical) == false, Study(Empirical(true)))) == 0
+end
+
+
+@testset "filter database on Study level" begin
+    test_db = RecordDatabase()
+
+    test_db += Record(
+        rater="VK",
+        id="2a129694-550c-4396-be6f-00507b1dc7ba",
+        Lang("en"),
+        Study(
+            N(100),
+            Model(Standardized(true)),
+            Model(Standardized(false))
+        ),
+        Study(
+            N(200),
+            Model(Standardized(false)),
+            Model(Standardized(false))
+        )
+    )
+
+    test_db += Record(
+        rater="VK",
+        id="7548949d-b2f5-436f-8577-4237fb51d5a7",
+        Lang("de"),
+        Study(
+            N(100),
+            Model(Standardized(true)),
+            Model(Standardized(false))
+        )
+    )
+
+    test_db += Record(
+        rater="VK",
+        id="7548949d-b2f5-436f-8577-4237fb51d5a8",
+        Lang("de")
+    )
+
+    filtered_study = filter(x -> rating(x, :N) == 200, test_db, Study())
+
+    ## Check if the correct studies were filtered
+    @test length(Study(filtered_study[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")])) == 1
+    @test rating(Study(filtered_study[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")])[1], :N) == 200
+
+    ## Dealing with cases where no case fits the filter function or where there is no Model in a Study:
+    @test length(Study(filtered_study[Base.UUID("7548949d-b2f5-436f-8577-4237fb51d5a7")])) == 0
+    @test length(Study(filtered_study[Base.UUID("7548949d-b2f5-436f-8577-4237fb51d5a8")])) == 0
+end
+
+
+@testset "filter database on Model level" begin
+    test_db = RecordDatabase()
+
+    test_db += Record(
+        rater="VK",
+        id="2a129694-550c-4396-be6f-00507b1dc7ba",
+        Lang("en"),
+        Study(
+            N(100),
+            Model(Standardized(true)),
+            Model(Standardized(false))
+        ),
+        Study(
+            N(200),
+            Model(Standardized(false)),
+            Model(Standardized(false))
+        )
+    )
+
+    test_db += Record(
+        rater="VK",
+        id="7548949d-b2f5-436f-8577-4237fb51d5a7",
+        Lang("de"),
+        Study(
+            N(100),
+            Model(Standardized(true)),
+            Model(Standardized(false))
+        )
+    )
+
+    test_db += Record(
+        rater="VK",
+        id="7548949d-b2f5-436f-8577-4237fb51d5a8",
+        Lang("de"),
+        Study(
+            N(100)
+        )
+    )
+
+    filtered_model = filter(x -> rating(x, :Standardized) == true, test_db, Model())
+
+    ## Check if the correct studies were filtered
+    @test rating(Model(Study(filtered_model[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")])[1])[1], :Standardized) == true
+    @test length(Model(Study(filtered_model[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")])[1])) == 1
+    @test length(Model(Study(filtered_model[Base.UUID("7548949d-b2f5-436f-8577-4237fb51d5a7")])[1])) == 1
+    @test rating(Model(Study(filtered_model[Base.UUID("7548949d-b2f5-436f-8577-4237fb51d5a7")])[1])[1], :Standardized) == true
+
+    ## Dealing with cases where no case fits the filter function or where there is no Model in a Study:
+    @test length(Model(Study(filtered_model[Base.UUID("7548949d-b2f5-436f-8577-4237fb51d5a8")])[1])) == 0
+    @test length(Model(Study(filtered_model[Base.UUID("2a129694-550c-4396-be6f-00507b1dc7ba")])[2])) == 0
+
+end

--- a/test/judgements/judgement.jl
+++ b/test/judgements/judgement.jl
@@ -61,3 +61,10 @@ end
     isnothing(check_judgement_level(Observation()))
     @test_throws ArgumentError check_judgement_level(N(100), ( StudyJudgement(), ))  
 end
+
+
+@testset "JudgementLevel rating" begin
+    @test rating(get(Model(Standardized(true)), :Standardized)) == true
+    @test rating(Model(Standardized(true)), :Standardized)
+    @test rating(Study(N(100)), :N) == 100
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,4 +20,5 @@ using StenoGraphs
     include("extractors.jl")
     include("database.jl")
     include("judgements/dict.jl")
+    include("filter.jl")
 end


### PR DESCRIPTION
Implemented a filter function for databases.
Wrote a method for `Base.filter()` that takes a filter function, a database and, additionally, the level on which the filter function should be applied (Record, Study, Model, Taxon). 
The filter function can also work with `rating()` or `certainty()` so the function definition works a bit more naturally, see documentation of `filter()`.